### PR TITLE
:bug: adding accuracy to the method

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -24,8 +24,11 @@ public class MethodCallSymbolProvider implements SymbolProvider {
         List<SymbolInformation> symbols = new ArrayList<>();
         // For Method Calls we will need to do the local variable trick
         try {
-            logInfo("match: " + match);
             MethodReferenceMatch m = (MethodReferenceMatch) match;
+            if (m.getAccuracy() != SearchMatch.A_ACCURATE) {
+                logInfo("Found match that was not exact: " + m);
+                return symbols;
+            }
             IMethod e = (IMethod) m.getElement();
             SymbolInformation symbol = new SymbolInformation();
             symbol.setName(e.getElementName());


### PR DESCRIPTION
When getting methods with type erasure, you get a ton of results.

We may in the future, want to make this optional:

This is what an inaccurate search is: 
```
The search result is potentially a match for the search pattern,
but the search engine is unable to fully check it (for example, because
there are errors in the code or the classpath are not correctly set).
```

