### PR TITLE
Disable tycho strictVersions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,14 @@
           </target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <strictVersions>false</strictVersions>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Disable tycho strictVersions until project uses proper releases, this prevents tycho version validation to fail on new versioned builds.