### PR TITLE
:ghost: Fix maven index and update it weekly

### DIFF
--- a/.github/workflows/multi-arch_images_build.yaml
+++ b/.github/workflows/multi-arch_images_build.yaml
@@ -20,23 +20,14 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: Install pigz
-      shell: bash
-      run: sudo apt-get install -y pigz
     - name: Checkout Push to Registry action
       uses: konveyor/release-tools/build-push-quay@main
       with:
         architectures: "amd64, arm64, ppc64le, s390x"
         containerfile: "./Dockerfile"
-        extra-args: "--build-arg BUILDENV=github"
         image_name: "jdtls-server-base"
         image_namespace: "konveyor"
         image_registry: "quay.io"
         quay_publish_robot: ${{ secrets.QUAY_PUBLISH_ROBOT }}
         quay_publish_token: ${{ secrets.QUAY_PUBLISH_TOKEN }}
-        pre_build_cmd: |
-                    curl -s -o nexus-maven-repository-index.gz https://repo.maven.apache.org/maven2/.index/nexus-maven-repository-index.gz
-                    unpigz nexus-maven-repository-index.gz
-                    cat nexus-maven-repository-index | parallel -j150% --pipe --block 100M --cat grep -oaP "'[a-z][a-zA-Z0-9_.-]+\|[a-zA-Z][a-zA-Z0-9_.-]+\|([a-zA-Z0-9_.-]+\|)?(sources|pom|jar|maven-plugin|ear|ejb|ejb-client|java-source|rar|war)\|(jar|war|ear|pom|war|rar)'" {} | cut -d'|' -f1 | sed 's/$/.*/' | sort | uniq > hack/maven.default.index
-                    rm -rf nexus-maven-repository-index
         ref: ${{ github.ref }}

--- a/.github/workflows/update_maven_index.yaml
+++ b/.github/workflows/update_maven_index.yaml
@@ -1,0 +1,25 @@
+name: 'Generate Maven Index and Commit'
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 3 * * 0'
+
+jobs:
+  build_and_commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install podman
+      shell: bash
+      run: sudo apt-get install -y podman
+    - name:
+      run: |
+        podman build -f hack/Dockerfile -t export hack/
+        podman cp $(podman create export):/unpack/maven.default.index ./hack
+    - name: Commit Updated maven.default.index update
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: ":ghost: Update Maven Index"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,7 @@ RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.16.0
         rm -rf jdtls.tar.gz
 
 FROM registry.access.redhat.com/ubi9/ubi AS maven-index
-ARG BUILDENV=local
 COPY hack/maven.default.index /maven.default.index
-RUN if [ $BUILDENV == "local" ]; then curl -s -o nexus-maven-repository-index.gz https://repo.maven.apache.org/maven2/.index/nexus-maven-repository-index.gz &&\
-	zgrep -oaP '[a-z][a-zA-Z0-9_.-]+\|[a-zA-Z][a-zA-Z0-9_.-]+\|([a-zA-Z0-9_.-]+\|)?(sources|pom|jar|maven-plugin|ear|ejb|ejb-client|java-source|rar|war)\|(jar|war|ear|pom|war|rar)' nexus-maven-repository-index.gz | cut -d'|' -f1 | sed 's/$/.*/' | sort | uniq > /maven.default.index &&\
-        rm -rf nexus-maven-repository-index.gz; fi
-
 FROM registry.access.redhat.com/ubi9/ubi AS fernflower
 RUN dnf install -y maven-openjdk17 wget --setopt=install_weak_deps=False && dnf clean all && rm -rf /var/cache/dnf
 RUN wget --quiet https://github.com/JetBrains/intellij-community/archive/refs/tags/idea/231.9011.34.tar.gz -O intellij-community.tar && tar xf intellij-community.tar intellij-community-idea-231.9011.34/plugins/java-decompiler/engine && rm -rf intellij-community.tar

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,0 +1,27 @@
+FROM registry.access.redhat.com/ubi9/ubi
+RUN dnf module enable -y maven:3.8 \
+ && dnf clean all \
+ && dnf -y update \
+ && dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+ && dnf -y install maven-openjdk17 git parallel pigz \
+ && dnf clean all
+RUN git clone https://github.com/apache/maven-indexer.git
+RUN cd maven-indexer/indexer-cli && mvn install -Denforcer.skip=true -Dmaven.test.skip=true
+RUN mkdir -p /unpack/index
+COPY export.java /unpack/export.java
+RUN cd /unpack/index \
+ && curl -s -o nexus-maven-repository-index.gz https://repo.maven.apache.org/maven2/.index/nexus-maven-repository-index.gz \
+ && java -jar $(find /root/.m2 -name indexer-cli-*-cli.jar) -u nexus-maven-repository-index.gz \
+ && rm nexus-maven-repository-index.gz \
+ && cd /unpack \
+ && java -classpath $(find /root/.m2 -name lucene-core*.jar) export.java | pigz -k -p$(nproc) > export.gz \
+ && rm -rf index \
+ && unpigz -p$(nproc) export.gz \
+ && cat export | \
+    parallel -j150% --pipe --block 100M --cat \
+    grep -oaP "'[a-z][a-zA-Z0-9_.-]+\|[a-zA-Z][a-zA-Z0-9_.-]+\|([a-zA-Z0-9_.-]+\|)?(sources|pom|jar|maven-plugin|ear|ejb|ejb-client|java-source|rar|war)\|(jar|war|ear|pom|war|rar)'" {} | \
+    cut -d'|' -f1 | \
+    sed 's/$/.*/' | \
+    sort | \
+    uniq > maven.default.index \
+ && rm -rf export

--- a/hack/export.java
+++ b/hack/export.java
@@ -1,0 +1,23 @@
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+public class Export {
+  public static void main(String[] args) throws Exception {
+    Path path = Paths.get("index");
+    Directory index = FSDirectory.open(path);
+    IndexReader reader = DirectoryReader.open(index);
+
+    int num = reader.numDocs();
+    for ( int i = 0; i < num; i++)
+    {
+        Document d = reader.document( i);
+        System.out.println( "d=" +d);
+    }
+    reader.close();
+  }
+}


### PR DESCRIPTION
This should speed up builds both locally and in GH actions. It also solves problems for downstream.

I also believe we're missing some valid entries with the other script trying to run over the binary file. For instance, `org.apache.karaf.cellar.samples.dosgi.greeter.*` was added and bad versions of this beginning with q, t, and u were removed.

The PR from a test run here shows what look like a bunch of valid entries being added and invalid entries being removed.
https://github.com/jmontleon/java-analyzer-bundle/commit/176aada5667d1d3a51c108b04ec4e7c91eae01ba
