### PR TITLE
:ghost: Improve maven.default.index gen

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -2,8 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 RUN dnf module enable -y maven:3.8 \
  && dnf clean all \
  && dnf -y update \
- && dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
- && dnf -y install maven-openjdk17 git parallel pigz \
+ && dnf -y install maven-openjdk17 git \
  && dnf clean all
 RUN git clone https://github.com/apache/maven-indexer.git
 RUN cd maven-indexer/indexer-cli && mvn install -Denforcer.skip=true -Dmaven.test.skip=true
@@ -14,14 +13,5 @@ RUN cd /unpack/index \
  && java -jar $(find /root/.m2 -name indexer-cli-*-cli.jar) -u nexus-maven-repository-index.gz \
  && rm nexus-maven-repository-index.gz \
  && cd /unpack \
- && java -classpath $(find /root/.m2 -name lucene-core*.jar) export.java | pigz -k -p$(nproc) > export.gz \
- && rm -rf index \
- && unpigz -p$(nproc) export.gz \
- && cat export | \
-    parallel -j150% --pipe --block 100M --cat \
-    grep -oaP "'[a-z][a-zA-Z0-9_.-]+\|[a-zA-Z][a-zA-Z0-9_.-]+\|([a-zA-Z0-9_.-]+\|)?(sources|pom|jar|maven-plugin|ear|ejb|ejb-client|java-source|rar|war)\|(jar|war|ear|pom|war|rar)'" {} | \
-    cut -d'|' -f1 | \
-    sed 's/$/.*/' | \
-    sort | \
-    uniq > maven.default.index \
- && rm -rf export
+ && java -cp $(find /root/.m2 -name lucene-core*.jar) export.java \
+ && rm -rf index

--- a/hack/export.java
+++ b/hack/export.java
@@ -1,23 +1,44 @@
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.TreeSet;
+import java.util.Iterator;
+import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 
-public class Export {
+public class export {
   public static void main(String[] args) throws Exception {
     Path path = Paths.get("index");
     Directory index = FSDirectory.open(path);
+    DirectoryReader dreader = DirectoryReader.open(index);
     IndexReader reader = DirectoryReader.open(index);
+    StoredFields storedFields = reader.storedFields();
+
+    TreeSet<String> groupIds = new TreeSet<String>();
 
     int num = reader.numDocs();
-    for ( int i = 0; i < num; i++)
+    for (int i = 0; i < num; i++)
     {
-        Document d = reader.document( i);
-        System.out.println( "d=" +d);
+        Document d = storedFields.document(i);
+        if (d.get("u") != null) {
+          groupIds.add(d.get("u").split("\\|")[0] + ".*");
+        }
     }
+
+    BufferedWriter out = new BufferedWriter(new FileWriter("maven.default.index"));
+    Iterator it = groupIds.iterator();
+    while(it.hasNext()) {
+      out.write(it.next().toString());
+      out.newLine();
+    }
+
+    out.close();
     reader.close();
   }
 }


### PR DESCRIPTION
This gets rid of all the piping, compressing, uncompressing, grep/sort/awk stuff, speeds things up a little and adds some more missing entries.

Example run:
https://github.com/jmontleon/java-analyzer-bundle/actions/runs/6113603987/job/16593418996

Results compared to previous run:
https://github.com/jmontleon/java-analyzer-bundle/commit/32a3bb2a8a4dd3cdcb0f9049160e96b557b877d9