### PR TITLE
Upgrade maven to 3.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,13 @@ RUN microdnf install -y go-toolset && microdnf clean all && rm -rf /var/cache/dn
 RUN go install golang.org/x/tools/gopls@latest
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
-RUN microdnf install -y python39 maven-openjdk17 java-17-openjdk-devel golang-bin --nodocs --setopt=install_weak_deps=0 && microdnf clean all && rm -rf /var/cache/dnf
+RUN microdnf install -y python39 java-17-openjdk-devel golang-bin tar gzip --nodocs --setopt=install_weak_deps=0 && microdnf clean all && rm -rf /var/cache/dnf
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk
+RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz && \
+    tar -xzf /tmp/apache-maven.tar.gz -C /usr/local/ && \
+    ln -s /usr/local/apache-maven-3.9.5/bin/mvn /usr/bin/mvn && \
+    rm /tmp/apache-maven.tar.gz
+ENV M2_HOME /usr/local/apache-maven-3.9.5
 COPY --from=gopls-build /root/go/bin/gopls /root/go/bin/gopls
 COPY --from=jdtls-download /jdtls /jdtls/
 COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/1.0.0-SNAPSHOT/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/


### PR DESCRIPTION
For the analyzer to be able to run `mvn dependency:...` without the need for compilation, we need to upgrade maven to a newer version.

Related to https://github.com/konveyor/analyzer-lsp/issues/393