### PR TITLE
:ghost: Improve running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,5 @@ COPY --from=jdtls-download /jdtls /jdtls/
 COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/1.0.0-SNAPSHOT/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/
 COPY --from=fernflower /output/fernflower.jar /bin/fernflower.jar
 COPY --from=maven-index /maven.default.index /usr/local/etc/maven.default.index
+RUN ln -sf /root/.m2 /.m2 && chgrp -R 0 /root && chmod -R g=u /root
 CMD [ "/jdtls/bin/jdtls" ]


### PR DESCRIPTION
With this change we can at least run as non-root.

I would also proprose moving binaries that need to be accessible to all users be installed in /usr/local/bin. But as of right now it seems we have configs hard coded to this location.
https://github.com/konveyor/java-analyzer-bundle/blob/main/Dockerfile#L41

https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html

https://github.com/konveyor/analyzer-lsp/blob/f6cdf400bf2c7e236b050f31300e9e504e241d78/provider_settings.json.sample#L8

We could probably keep the handling to /root/.m2 similar, except update the permissions changes to only  adjust /root/.m2. Alternatively, set HOME=/ and set it up and adjust permissions there instead of linking it.