### PR TITLE
:sparkles: add ability to set search scope by file paths

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/RuleEntryParams.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/RuleEntryParams.java
@@ -2,25 +2,29 @@ package io.konveyor.tackle.core.internal;
 
 import static java.lang.String.format;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class RuleEntryParams {
-    
+
     private final String projectName;
     private final String query;
     private final int location;
     private final String analysisMode;
+    private final ArrayList<String> includedPaths;
 
     public RuleEntryParams(final String commandId, final List<Object> arguments) {
         @SuppressWarnings("unchecked")
         Map<String, Object> obj = (Map<String, Object>) arguments.stream().findFirst()
-                .orElseThrow(() -> new UnsupportedOperationException(format("Command '%s' must be called with one rule entry argument!", commandId)));
+                .orElseThrow(() -> new UnsupportedOperationException(
+                        format("Command '%s' must be called with one rule entry argument!", commandId)));
 
         this.projectName = (String) obj.get("project");
         this.query = (String) obj.get("query");
         this.location = Integer.parseInt((String) obj.get("location"));
         this.analysisMode = (String) obj.get("analysisMode");
+        this.includedPaths = (ArrayList<String>) obj.get("includedPaths");
     }
 
     public String getProjectName() {
@@ -39,4 +43,7 @@ public class RuleEntryParams {
         return analysisMode;
     }
 
+    public ArrayList<String> getIncludedPaths() {
+        return includedPaths;
+    }
 }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SampleDelegateCommandHandler.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SampleDelegateCommandHandler.java
@@ -189,6 +189,11 @@ public class SampleDelegateCommandHandler implements IDelegateCommandHandler {
                         fragmentPath = fragmentPath.removeFirstSegments(1);
                         for (String includedPath : includedPaths) {
                             IPath includedIPath = Path.fromOSString(includedPath);
+                            // when there are more than one sub-projects, the paths are of form
+                            // <project-name>/src/main/java/
+                            if (includedPath.startsWith(proj.getElementName())) {
+                                includedIPath = includedIPath.removeFirstSegments(1);
+                            }
                             // instead of comparing path strings, comparing segments is better for 2 reasons:
                             // - we don't have to worry about redundant . / etc in input
                             // - matching sub-trees is easier with segments than strings


### PR DESCRIPTION
This adds ability to create a search scope from file paths, and also disables test files from scope (this is the first true argument to createSearchScope function). Note that the search scope can only be set at a package level. Haven't yet figured out how to get it down to compilation units. But I think this is enough for now. 