### PR TITLE
:bug: Improve accuracy of METHOD_CALL and CONSTRUCTOR_CALL matches

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -18,14 +18,17 @@ jobs:
         else
           echo "::set-output name=ref::refs/pull/$PULL_REQUEST_NUMBER/merge"
         fi
+    
     - name: checkout
       uses: actions/checkout@v3
+    
     - name: Checkout tools repo
       uses: actions/checkout@v3
       with:
         repository: konveyor/analyzer-lsp
         path: analyzer-lsp
         ref: "${{ steps.extract_analyzer_pull_request_number.outputs.ref }}"
+
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
@@ -35,24 +38,23 @@ jobs:
 
     - name: Build bundle base image
       run: |
-        docker build -t quay.io/konveyor/jdtls-server-base:latest .
-    - name: build analyzer-lsp Dockerfile
+        podman build -t quay.io/konveyor/jdtls-server-base:latest .
+    
+    - name: build java provider and save image
+      working-directory: analyzer-lsp
       run: |
-        docker build -f analyzer-lsp/Dockerfile -t quay.io/konveyor/analyzer-lsp:latest analyzer-lsp
-        docker tag quay.io/konveyor/analyzer-lsp:latest analyzer-lsp
-    - name: Build addon and save image
-      working-directory: tackle2-addon-analyzer
-      run: |
-        IMG=quay.io/konveyor/tackle2-addon-analyzer:latest make image-podman
-        podman save -o /tmp/tackle2-addon-analyzer.tar quay.io/konveyor/tackle2-addon-analyzer:latest
+        make build-java-provider
+        podman tag java-provider quay.io/konveyor/java-external-provider:latest
+        podman save -o /tmp/java-provider.tar quay.io/konveyor/java-external-provider:latest
+    
     - name: Upload image as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: tackle2-addon-analyzer
-        path: /tmp/tackle2-addon-analyzer.tar
+        name: java-provider
+        path: /tmp/java-provider.tar
         retention-days: 1
   e2e:
     needs: build-addon
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
-      component_name: tackle2-addon-analyzer
+      component_name: java-provider

--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -6,17 +6,26 @@ jobs:
   build-addon:
     name: Build tackle2-addon-analyzer
     runs-on: ubuntu-20.04
+    outputs:
+      api_tests_ref: ${{ steps.extract_info.outputs.API_TESTS_REF }}
     strategy:
       fail-fast: false
     steps:
     - name: Extract pull request number from PR description
-      id: extract_analyzer_pull_request_number
+      id: extract_info
       run: |
-        PULL_REQUEST_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[A|a]nalyzer.?[P|p][R|r]: \K\d+' || true)
-        if [ -z "$PULL_REQUEST_NUMBER" ]; then
-          echo "::set-output name=ref::main"
+        ANALYZER_PR=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[A|a]nalyzer.?[P|p][R|r]: \K\d+' || true)
+        if [ -z "$ANALYZER_PR" ]; then
+          echo "ANALYZER_REF=${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=ref::refs/pull/$PULL_REQUEST_NUMBER/merge"
+          echo "ANALYZER_REF=refs/pull/$ANALYZER_PR/merge" >> $GITHUB_OUTPUT
+        fi
+
+        API_TESTS_PR=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[A|a]pi *[T|t]ests *[P|p][R|r]: \K\d+' || true)
+        if [ -z "$API_TESTS_PR" ]; then
+          echo "API_TESTS_REF=${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
+        else
+          echo "API_TESTS_REF=refs/pull/$API_TESTS_PR/merge" >> $GITHUB_OUTPUT
         fi
     
     - name: checkout
@@ -27,7 +36,7 @@ jobs:
       with:
         repository: konveyor/analyzer-lsp
         path: analyzer-lsp
-        ref: "${{ steps.extract_analyzer_pull_request_number.outputs.ref }}"
+        ref: "${{ steps.extract_info.outputs.ANALYZER_REF }}"
 
     - uses: actions/checkout@v3
       with:
@@ -58,3 +67,4 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
       component_name: java-provider
+      api_tests_ref: "${{ needs.build-addon.outputs.api_tests_ref }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.16.0/jdt-language-server-1.16.0-202209291445.tar.gz &&\
+RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.36.0/jdt-language-server-1.36.0-202405301306.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -6,14 +6,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.search.MethodReferenceMatch;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 
-public class ConstructorCallSymbolProvider implements SymbolProvider {
+public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery {
+    public String query;
+
     @Override
     public List<SymbolInformation> get(SearchMatch match) throws CoreException {
         List<SymbolInformation> symbols = new ArrayList<>();
@@ -32,11 +42,50 @@ public class ConstructorCallSymbolProvider implements SymbolProvider {
             }
             symbol.setContainerName(mod.getParent().getElementName());
             symbol.setLocation(getLocation(mod, match));
-            symbols.add(symbol);
+            if (this.query.contains(".")) {
+                ICompilationUnit unit = mod.getCompilationUnit();
+                ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
+                astParser.setSource(unit);
+                astParser.setResolveBindings(true);
+                CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
+                cu.accept(new ASTVisitor() {
+                    // we are only doing this for MethodInvocation right now
+                    // look into MethodDeclaration if needed
+                    public boolean visit(MethodInvocation node) {
+                        try {
+                            IMethodBinding binding = node.resolveMethodBinding();
+                            if (binding != null) {
+                                // get fqn of the method being called
+                                ITypeBinding declaringClass = binding.getDeclaringClass();
+                                if (declaringClass != null) {
+                                    String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
+                                    // match fqn with query pattern
+                                    if (fullyQualifiedName.matches(getCleanedQuery(query))) {
+                                        symbols.add(symbol);
+                                    } else {
+                                        logInfo("fqn " + fullyQualifiedName + " did not match with " + query);
+                                    }
+                                }
+                            } 
+                        } catch (Exception e) {
+                            logInfo("error determining accuracy of match: " + e);
+                        }
+                        return true;
+                    }
+                });
+            } else {
+                symbols.add(symbol);
+            }
         } catch (Exception e) {
             logInfo("unable to get constructor: " + e);
             return null;
         }
         return symbols;
+    }
+
+    @Override
+    public void setQuery(String query) {
+        // TODO Auto-generated method stub
+        this.query = query;
     }
 }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -48,31 +48,11 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                 astParser.setSource(unit);
                 astParser.setResolveBindings(true);
                 CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
-                cu.accept(new ASTVisitor() {
-                    // we are only doing this for MethodInvocation right now
-                    // look into MethodDeclaration if needed
-                    public boolean visit(MethodInvocation node) {
-                        try {
-                            IMethodBinding binding = node.resolveMethodBinding();
-                            if (binding != null) {
-                                // get fqn of the method being called
-                                ITypeBinding declaringClass = binding.getDeclaringClass();
-                                if (declaringClass != null) {
-                                    String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
-                                    // match fqn with query pattern
-                                    if (fullyQualifiedName.matches(getCleanedQuery(query))) {
-                                        symbols.add(symbol);
-                                    } else {
-                                        logInfo("fqn " + fullyQualifiedName + " did not match with " + query);
-                                    }
-                                }
-                            } 
-                        } catch (Exception e) {
-                            logInfo("error determining accuracy of match: " + e);
-                        }
-                        return true;
-                    }
-                });
+                CustomASTVisitor visitor = new CustomASTVisitor(query, match);
+                cu.accept(visitor);
+                if (visitor.symbolMatches()) {
+                    symbols.add(symbol);
+                }
             } else {
                 symbols.add(symbol);
             }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/CustomASTVisitor.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/CustomASTVisitor.java
@@ -1,0 +1,86 @@
+package io.konveyor.tackle.core.internal.symbol;
+
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.search.SearchMatch;
+
+import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logInfo;
+
+public class CustomASTVisitor extends ASTVisitor {
+    private String query;
+    private SearchMatch match;
+    private boolean symbolMatches;
+
+
+    public CustomASTVisitor(String query, SearchMatch match) {
+        /*
+         * When comparing query pattern with an actual java element's fqn
+         * we need to make sure that * not preceded with a . are replaced
+         * by .* so that java regex works as expected on them
+        */
+        this.query = query.replaceAll("(?<!\\.)\\*", ".*");
+        this.symbolMatches = false;
+        this.match = match;
+    }
+
+    /*
+     * When visiting AST nodes, it may happen that we visit more nodes
+     * than needed. We need to ensure that we are only visiting ones
+     * that are found in the given search match. I wrote this for methods
+     * where I observed that a node starts at the beginning of line whereas match
+     * starts at an offset within that line. However, both end on the same position.
+     * This could differ for other locations. In that case, change logic based
+     * on type of the node you get.
+     */
+    private boolean shouldVisit(ASTNode node) {
+        return (this.match.getOffset() + this.match.getLength()) == 
+            (node.getStartPosition() + node.getLength());
+    }
+
+    /* 
+     * This is to get information from a MethodInvocation
+     * used for METHOD_CALL and CONSTRUCTOR_CALL matches
+     * we only discard a match only when we can tell for sure
+     * returning false stops further visits
+    */
+    @Override
+    public boolean visit(MethodInvocation node) {
+        try {
+            if (!this.shouldVisit(node)) {
+                return true;
+            }
+            IMethodBinding binding = node.resolveMethodBinding();
+            if (binding != null) {
+                // get fqn of the method being called
+                ITypeBinding declaringClass = binding.getDeclaringClass();
+                if (declaringClass != null) {
+                    String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
+                    // match fqn with query pattern
+                    if (fullyQualifiedName.matches(this.query)) {
+                        this.symbolMatches = true;
+                        return false;
+                    } else {
+                        logInfo("method fqn " + fullyQualifiedName + " did not match with " + query);
+                        return true;
+                    }
+                }
+            } 
+            // sometimes binding or declaring class cannot be found, usually due to errors
+            // in source code. in that case, we will fallback and accept the match
+            this.symbolMatches = true;
+            return false;
+        } catch (Exception e) {
+            logInfo("error visiting MethodInvocation node: " + e);
+            // this is so that we fallback to old approach and we dont lose a result
+            this.symbolMatches = true;
+            return false;
+        }
+    }
+
+    public boolean symbolMatches() {
+        return this.symbolMatches;
+    }
+}

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/CustomASTVisitor.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/CustomASTVisitor.java
@@ -1,6 +1,8 @@
 package io.konveyor.tackle.core.internal.symbol;
 
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -9,13 +11,30 @@ import org.eclipse.jdt.core.search.SearchMatch;
 
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logInfo;
 
+/*
+ * SearchEngine we use often gives us more matches than needed when
+ * query contains a * and/or contains a fqn. e.g. java.io.paths.get* 
+ * This class exists to help us get accurate results for such queries
+ * For different type of symbols we get from a match, we try to
+ * get fqn of that symbol and ensure it matches the given query
+ * (pgaikwad): if you can, please make the visit() functions DRYer
+ */
 public class CustomASTVisitor extends ASTVisitor {
     private String query;
     private SearchMatch match;
     private boolean symbolMatches;
+    private QueryLocation location;
 
+    /* 
+     * we re-use this same class for different locations in a query
+     * we should only be visiting nodes specific to a location, not all
+    */
+    public enum QueryLocation {
+        METHOD_CALL,
+        CONSTRUCTOR_CALL,
+    }
 
-    public CustomASTVisitor(String query, SearchMatch match) {
+    public CustomASTVisitor(String query, SearchMatch match, QueryLocation location) {
         /*
          * When comparing query pattern with an actual java element's fqn
          * we need to make sure that * not preceded with a . are replaced
@@ -24,16 +43,19 @@ public class CustomASTVisitor extends ASTVisitor {
         this.query = query.replaceAll("(?<!\\.)\\*", ".*");
         this.symbolMatches = false;
         this.match = match;
+        // depending on which location the query was for we only want to
+        // visit certain nodes
+        this.location = location;
     }
 
     /*
-     * When visiting AST nodes, it may happen that we visit more nodes
-     * than needed. We need to ensure that we are only visiting ones
-     * that are found in the given search match. I wrote this for methods
-     * where I observed that a node starts at the beginning of line whereas match
-     * starts at an offset within that line. However, both end on the same position.
-     * This could differ for other locations. In that case, change logic based
-     * on type of the node you get.
+     * When visiting AST nodes, it may happen that we visit more nodes than
+     * needed. We need to ensure that we are only visiting ones that are found
+     * in the given search match. I wrote this for methods / constructors where 
+     * I observed that node starts at the beginning of line whereas match starts 
+     * at an offset within that line. However, both end on the same position. This 
+     * could differ for other locations. In that case, change logic based on type of
+     * the node you get.
      */
     private boolean shouldVisit(ASTNode node) {
         return (this.match.getOffset() + this.match.getLength()) == 
@@ -41,17 +63,16 @@ public class CustomASTVisitor extends ASTVisitor {
     }
 
     /* 
-     * This is to get information from a MethodInvocation
-     * used for METHOD_CALL and CONSTRUCTOR_CALL matches
-     * we only discard a match only when we can tell for sure
+     * This is to get information from a MethodInvocation, used for METHOD_CALL
+     * we discard a match only when we can tell for sure. otherwise we accept
      * returning false stops further visits
     */
     @Override
     public boolean visit(MethodInvocation node) {
+        if (this.location != QueryLocation.METHOD_CALL || !this.shouldVisit(node)) {
+            return true;
+        }
         try {
-            if (!this.shouldVisit(node)) {
-                return true;
-            }
             IMethodBinding binding = node.resolveMethodBinding();
             if (binding != null) {
                 // get fqn of the method being called
@@ -67,17 +88,98 @@ public class CustomASTVisitor extends ASTVisitor {
                         return true;
                     }
                 }
-            } 
+            }
+            logInfo("failed to get accurate info for MethodInvocation, falling back");
             // sometimes binding or declaring class cannot be found, usually due to errors
             // in source code. in that case, we will fallback and accept the match
             this.symbolMatches = true;
             return false;
         } catch (Exception e) {
             logInfo("error visiting MethodInvocation node: " + e);
-            // this is so that we fallback to old approach and we dont lose a result
+            // this is so that we fallback and don't lose a match when we fail
             this.symbolMatches = true;
             return false;
         }
+    }
+    
+    /* 
+     * This is to get information from a ConstructorInvocation, used for CONSTRUCTOR_CALL
+     * we discard a match only when we can tell for sure. otherwise we accept
+     * returning false stops further visits
+    */
+    @Override
+    public boolean visit(ConstructorInvocation node) {
+        if (this.location != QueryLocation.CONSTRUCTOR_CALL || !this.shouldVisit(node)) {
+            return true;
+        }
+        try {
+            IMethodBinding binding = node.resolveConstructorBinding();
+            if (binding != null) {
+                // get fqn of the method being called
+                ITypeBinding declaringClass = binding.getDeclaringClass();
+                if (declaringClass != null) {
+                    String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
+                    // match fqn with query pattern
+                    if (fullyQualifiedName.matches(this.query)) {
+                        this.symbolMatches = true;
+                        return false;
+                    } else {
+                        logInfo("constructor fqn " + fullyQualifiedName + " did not match with " + query);
+                        return true;
+                    }
+                }
+            }
+            logInfo("failed to get accurate info for ConstructorInvocation, falling back");
+            // sometimes binding or declaring class cannot be found, usually due to errors
+            // in source code. in that case, we will fallback and accept the match
+            this.symbolMatches = true;
+            return false;
+        } catch (Exception e) {
+            logInfo("error visiting ConstructorInvocation node: " + e);
+            // this is so that we fallback and don't lose a match when we fail
+            this.symbolMatches = true;
+            return false;
+        }    
+    }
+
+    /* 
+     * This is to get information from a ClassInstanceCreation, used for CONSTRUCTOR_CALL
+     * we discard a match only when we can tell for sure. otherwise we accept
+     * returning false stops further visits
+    */
+    @Override
+    public boolean visit(ClassInstanceCreation node) {
+        if (this.location != QueryLocation.CONSTRUCTOR_CALL || !this.shouldVisit(node)) {
+            return true;
+        }
+        try {
+            IMethodBinding binding = node.resolveConstructorBinding();
+            if (binding != null) {
+                // get fqn of the method being called
+                ITypeBinding declaringClass = binding.getDeclaringClass();
+                if (declaringClass != null) {
+                    String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
+                    // match fqn with query pattern
+                    if (fullyQualifiedName.matches(this.query)) {
+                        this.symbolMatches = true;
+                        return false;
+                    } else {
+                        logInfo("constructor fqn " + fullyQualifiedName + " did not match with " + query);
+                        return true;
+                    }
+                }
+            }
+            logInfo("failed to get accurate info for ClassInstanceCreation, falling back");
+            // sometimes binding or declaring class cannot be found, usually due to errors
+            // in source code. in that case, we will fallback and accept the match
+            this.symbolMatches = true;
+            return false;
+        } catch (Exception e) {
+            logInfo("error visiting ConstructorInvocation node: " + e);
+            // this is so that we fallback and don't lose a match when we fail
+            this.symbolMatches = true;
+            return false;
+        }    
     }
 
     public boolean symbolMatches() {

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -33,6 +33,11 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
         try {
             MethodReferenceMatch m = (MethodReferenceMatch) match;
             IMethod e = (IMethod) m.getElement();
+            SymbolInformation symbol = new SymbolInformation();
+            symbol.setName(e.getElementName());
+            symbol.setKind(convertSymbolKind(e));
+            symbol.setContainerName(e.getParent().getElementName());
+            symbol.setLocation(getLocation(e, match));
             if (this.query.contains(".")) {
                 ICompilationUnit unit = e.getCompilationUnit();
                 ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
@@ -52,11 +57,6 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                                     String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
                                     // match fqn with query pattern
                                     if (fullyQualifiedName.matches(getCleanedQuery(query))) {
-                                        SymbolInformation symbol = new SymbolInformation();
-                                        symbol.setName(e.getElementName());
-                                        symbol.setKind(convertSymbolKind(e));
-                                        symbol.setContainerName(e.getParent().getElementName());
-                                        symbol.setLocation(getLocation(e, match));
                                         symbols.add(symbol);
                                     } else {
                                         logInfo("fqn " + fullyQualifiedName + " did not match with " + query);
@@ -70,11 +70,6 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                     }
                 });
             } else {
-                SymbolInformation symbol = new SymbolInformation();
-                symbol.setName(e.getElementName());
-                symbol.setKind(convertSymbolKind(e));
-                symbol.setContainerName(e.getParent().getElementName());
-                symbol.setLocation(getLocation(e, match));
                 symbols.add(symbol);
             }
         } catch (Exception e) {

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -5,10 +5,18 @@ import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logInfo;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.search.MethodReferenceMatch;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.lsp4j.SymbolInformation;
@@ -25,12 +33,50 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
         try {
             MethodReferenceMatch m = (MethodReferenceMatch) match;
             IMethod e = (IMethod) m.getElement();
-            SymbolInformation symbol = new SymbolInformation();
-            symbol.setName(e.getElementName());
-            symbol.setKind(convertSymbolKind(e));
-            symbol.setContainerName(e.getParent().getElementName());
-            symbol.setLocation(getLocation(e, match));
-            symbols.add(symbol);
+            if (this.query.contains(".")) {
+                ICompilationUnit unit = e.getCompilationUnit();
+                ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
+                astParser.setSource(unit);
+                astParser.setResolveBindings(true);
+                CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
+                cu.accept(new ASTVisitor() {
+                    // we are only doing this for MethodInvocation right now
+                    // look into MethodDeclaration if needed
+                    public boolean visit(MethodInvocation node) {
+                        try {
+                            IMethodBinding binding = node.resolveMethodBinding();
+                            if (binding != null) {
+                                // get fqn of the method being called
+                                ITypeBinding declaringClass = binding.getDeclaringClass();
+                                if (declaringClass != null) {
+                                    String fullyQualifiedName = declaringClass.getQualifiedName() + "." + binding.getName();
+                                    // match fqn with query pattern
+                                    if (fullyQualifiedName.matches(getCleanedQuery(query))) {
+                                        SymbolInformation symbol = new SymbolInformation();
+                                        symbol.setName(e.getElementName());
+                                        symbol.setKind(convertSymbolKind(e));
+                                        symbol.setContainerName(e.getParent().getElementName());
+                                        symbol.setLocation(getLocation(e, match));
+                                        symbols.add(symbol);
+                                    } else {
+                                        logInfo("fqn " + fullyQualifiedName + " did not match with " + query);
+                                    }
+                                }
+                            } 
+                        } catch (Exception e) {
+                            logInfo("error determining accuracy of match: " + e);
+                        }
+                        return true;
+                    }
+                });
+            } else {
+                SymbolInformation symbol = new SymbolInformation();
+                symbol.setName(e.getElementName());
+                symbol.setKind(convertSymbolKind(e));
+                symbol.setContainerName(e.getParent().getElementName());
+                symbol.setLocation(getLocation(e, match));
+                symbols.add(symbol);
+            }
         } catch (Exception e) {
             logInfo("unable to convert for variable: " + e);
         }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -167,4 +167,13 @@ public interface SymbolProvider {
 		position.setLine(coords[0]);
 		position.setCharacter(coords[1]);
 	}
+
+    /*
+     * When comparing query pattern with an actual found java element's fqn
+     * we need to make sure that * that are not preceded with a . are replaced
+     * by .* so that java regex works as expected on them
+     */
+    default String getCleanedQuery(String query) {
+        return query.replaceAll("(?<!\\.)\\*", ".*");
+    }
 }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -20,7 +20,6 @@ import org.eclipse.jdt.core.IPackageDeclaration;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.SourceRange;
-import org.eclipse.jdt.core.search.MethodReferenceMatch;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -193,6 +192,7 @@ public interface SymbolProvider {
         if (queryQualification != "" && location.getUri().contains(queryQualification.replaceAll(".", "/"))) {
             return true;
         }
+        query = query.replaceAll("(?<!\\.)\\*", ".*");
         if (unit != null) {
             try {
                 // check if the package declaration on the unit matches query

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -167,13 +167,4 @@ public interface SymbolProvider {
 		position.setLine(coords[0]);
 		position.setCharacter(coords[1]);
 	}
-
-    /*
-     * When comparing query pattern with an actual found java element's fqn
-     * we need to make sure that * that are not preceded with a . are replaced
-     * by .* so that java regex works as expected on them
-     */
-    default String getCleanedQuery(String query) {
-        return query.replaceAll("(?<!\\.)\\*", ".*");
-    }
 }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -182,6 +182,7 @@ public interface SymbolProvider {
      * we do this so that we can rule out a lot of matches before going the AST route
      */
     default boolean queryQualificationMatches(String query, ICompilationUnit unit, Location location) {
+        query = query.replaceAll("(?<!\\.)\\*", ".*");
         String queryQualification = "";
         int dotIndex = query.lastIndexOf('.');
         if (dotIndex > 0) {

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -12,12 +12,15 @@ import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IImportDeclaration;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.IPackageDeclaration;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.SourceRange;
+import org.eclipse.jdt.core.search.MethodReferenceMatch;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -167,4 +170,67 @@ public interface SymbolProvider {
 		position.setLine(coords[0]);
 		position.setCharacter(coords[1]);
 	}
+
+    /*
+     * Given a query, class and location of a Match, tells whether CompilationUnit of the match
+     * matches the qualification part of the query. For example, if the query is `konveyor.io.Util.get*`,
+     * qualification means `konveyor.io.Util`. This is so that we can improve accuracy of a match of 
+     * queries that are looking for FQNs. For query `konveyor.io.Util.get*`, returns true if either one is true:
+     *  1. match is found in the package `konveyor.io` or class `konveyor.io.Util` 
+     *  2. the compilation unit imports package `konveyor.io.Util` or `konveyor.io.*`
+     *  3. the compilation unit has a package declaration as `konveyor.io.Util`
+     * we do this so that we can rule out a lot of matches before going the AST route
+     */
+    default boolean queryQualificationMatches(String query, ICompilationUnit unit, Location location) {
+        String queryQualification = "";
+        int dotIndex = query.lastIndexOf('.');
+        if (dotIndex > 0) {
+            // for a query, java.io.paths.File*, queryQualification is java.io.paths
+            queryQualification = query.substring(0, dotIndex);
+        }
+        // check if the match was found in the same package as the query was looking for
+        if (queryQualification != "" && location.getUri().contains(queryQualification.replaceAll(".", "/"))) {
+            return true;
+        }
+        if (unit != null) {
+            try {
+                // check if the package declaration on the unit matches query
+                for (IPackageDeclaration packageDecl : unit.getPackageDeclarations()) {
+                    if (queryQualification != "" && packageDecl.getElementName().matches(queryQualification)) {
+                        return true;
+                    }
+                }
+                for (IImportDeclaration importDecl : unit.getImports()) {
+                    String importElement = importDecl.getElementName();
+                    String importQualification = "";
+                    int importDotIndex = query.lastIndexOf('.');
+                    if (importDotIndex > 0) {
+                        importQualification = query.substring(0, dotIndex);
+                    }
+                    // import can be absolute like java.io.paths.FileReader
+                    if (query.matches(importElement)) {
+                        return true;
+                    }
+                    if (importElement.matches(query)) {
+                        return true;
+                    }
+                    // an import can be java.io.paths.* or java.io.*
+                    if (importElement.contains("*")) {                     
+                        if (queryQualification != "") {
+                            // query is java.io.paths.File*, import is java.io.paths.*
+                            if (queryQualification.startsWith(importQualification)) {
+                                return true;
+                            }
+                            if (importElement.replaceAll(".*", "").matches(queryQualification)) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                logInfo("unable to determine accuracy of the match");
+            }
+        }
+        return false;
+    }
 }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -192,7 +192,6 @@ public interface SymbolProvider {
         if (queryQualification != "" && location.getUri().contains(queryQualification.replaceAll(".", "/"))) {
             return true;
         }
-        query = query.replaceAll("(?<!\\.)\\*", ".*");
         if (unit != null) {
             try {
                 // check if the package declaration on the unit matches query

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -7,7 +7,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner"
 			includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
-			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.31.0.202312111429" />
+			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.36.0.202405301306/" />
 		</location>
 		
 		
@@ -61,7 +61,7 @@
             <repository location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.22.0/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
API Tests PR: 155

This specifically addresses cases with queries containing FQN searches and/or *. We get more symbols than needed from jdt in these cases, we add logic to filter-out matches by inspecting full names of symbols.