### PR TITLE
Fix METHOD_CALL location in queryQualificationMatches

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -233,6 +233,10 @@ public interface SymbolProvider {
                             }
                         }
                     }
+                    // query can be java.io.paths.Path.checkPath()
+                    if (query.startsWith(importElement)) {
+                        return true;
+                    }
                 }
             } catch (Exception e) {
                 logInfo("unable to determine accuracy of the match");


### PR DESCRIPTION
Should fix https://github.com/konveyor/analyzer-lsp/issues/693

`System.out.println` will never match because `out` is a static field that references another class (`java.io.PrintStream`), but this should fix the rest of the cases.