### PR TITLE
Upgrade eclipse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -s -o jdtls.tar.gz https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz &&\
+RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.36.0/jdt-language-server-1.36.0-202405301306.tar.gz &&\
+RUN curl -s -o jdtls.tar.gz https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -7,7 +7,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner"
 			includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
-			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.36.0.202405301306/" />
+			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.38.0-202408011337/" />
 		</location>
 		
 		

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -7,7 +7,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner"
 			includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
-			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.38.0-202408011337/" />
+			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.38.0.202408011337/" />
 		</location>
 		
 		


### PR DESCRIPTION
Resolves `No repository found at https://download.eclipse.org/jdtls/snapshots/repository/1.36.0.202405301306`