### PR TITLE
:bug: Fix build (Java21 needed now) and also fix annotations when coming from java.lang (like @Override)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
+# JDK21 manual installation as there seem to be no packages for JDK21 yet
+FROM registry.access.redhat.com/ubi9/ubi AS jdk21
+WORKDIR /jdk21
+RUN dnf install -y wget tar --setopt=install_weak_deps=False && \
+    wget https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz && \
+    tar -xzf openjdk-21.0.2_linux-x64_bin.tar.gz
+
+# Download JDT language server
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
 RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz
-
 COPY jdtls-bin-override/jdtls.py /jdtls/bin/jdtls.py
 
+# Prepare Maven index for public artifact detection
 FROM registry.access.redhat.com/ubi9/ubi AS maven-index
 COPY hack/maven.default.index /maven.default.index
+
+# Build fernflower - use Java17 (cannot be built with Java21)
 FROM registry.access.redhat.com/ubi9/ubi AS fernflower
 RUN dnf install -y maven-openjdk17 wget --setopt=install_weak_deps=False && dnf clean all && rm -rf /var/cache/dnf
 RUN wget --quiet https://github.com/JetBrains/intellij-community/archive/refs/tags/idea/231.9011.34.tar.gz -O intellij-community.tar && tar xf intellij-community.tar intellij-community-idea-231.9011.34/plugins/java-decompiler/engine && rm -rf intellij-community.tar
@@ -17,27 +27,30 @@ RUN export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 RUN ./gradlew build -x test && rm -rf /root/.gradle
 RUN mkdir /output && cp ./build/libs/fernflower.jar /output
 
+# Build this LS plugin
 FROM registry.access.redhat.com/ubi9/ubi AS addon-build
-RUN dnf install -y maven-openjdk17 && dnf clean all && rm -rf /var/cache/dnf
+COPY --from=jdk21 /jdk21/jdk-21.0.2 /usr/lib/jvm/jdk-21.0.2
+RUN export JAVA_HOME=/usr/lib/jvm/jdk-21.0.2
+RUN dnf install -y maven --setopt=install_weak_deps=False && dnf clean all && rm -rf /var/cache/dnf
 WORKDIR /app
 COPY ./ /app/
-RUN export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-RUN JAVA_HOME=/usr/lib/jvm/java-17-openjdk mvn clean install -DskipTests=true
+RUN export JAVA_HOME=/usr/lib/jvm/jdk-21.0.2
+RUN JAVA_HOME=/usr/lib/jvm/jdk-21.0.2 mvn clean install -DskipTests=true
 
+# Install go
 FROM registry.access.redhat.com/ubi9/ubi-minimal as gopls-build
 RUN microdnf install -y go-toolset && microdnf clean all && rm -rf /var/cache/dnf
 RUN go install golang.org/x/tools/gopls@latest
 
+#
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 # Java 1.8 is required for backwards compatibility with older versions of Gradle
-RUN microdnf install -y python39 java-1.8.0-openjdk-devel java-17-openjdk-devel golang-bin tar gzip zip --nodocs --setopt=install_weak_deps=0 && microdnf clean all && rm -rf /var/cache/dnf
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk
+RUN microdnf install -y python39 java-1.8.0-openjdk-devel maven golang-bin tar gzip zip --nodocs --setopt=install_weak_deps=0 && microdnf clean all && rm -rf /var/cache/dnf
+# Manually installed jdk21
+COPY --from=jdk21 /jdk21/jdk-21.0.2 /usr/lib/jvm/jdk-21.0.2
+ENV JAVA_HOME=/usr/lib/jvm/jdk-21.0.2
 # Specify Java 1.8 home for usage with gradle wrappers
 ENV JAVA8_HOME /usr/lib/jvm/java-1.8.0-openjdk
-RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz && \
-    tar -xzf /tmp/apache-maven.tar.gz -C /usr/local/ && \
-    ln -s /usr/local/apache-maven-3.9.5/bin/mvn /usr/bin/mvn && \
-    rm /tmp/apache-maven.tar.gz
 ENV M2_HOME /usr/local/apache-maven-3.9.5
 
 # Copy "download sources" gradle task. This is needed to download project sources.

--- a/java-analyzer-bundle.core/.classpath
+++ b/java-analyzer-bundle.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/query/AnnotationQuery.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/query/AnnotationQuery.java
@@ -50,6 +50,10 @@ public class AnnotationQuery {
         // If the annotation query is happening on an annotation, the annotation field in the annotation query can be null
         if (isOnAnnotation() && getType() == null) {
             return true;
+        // Classes in the "java.lang" package are never imported, so there is a chance these annotations don't come
+        // as FQNs from the LS. Therefore lets check if the annotation is in "java.lang"
+        } else if (getType().startsWith("java.lang.") && !annotation.contains(".")) {
+            return Pattern.matches(getType().replace("java.lang.", ""), annotation);
         } else {
             return Pattern.matches(getType(), annotation);
         }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/WithAnnotationQuery.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/WithAnnotationQuery.java
@@ -191,7 +191,7 @@ public interface WithAnnotationQuery {
                     .filter(i -> i.getElementName().endsWith(name))
                     .findFirst()
                     .map(IImportDeclaration::getElementName)
-                    .orElse("");
+                    .orElse(name);
         }
     }
 

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -69,5 +69,5 @@
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
         </location>
     </locations>
-    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 </target>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <executionEnvironment>JavaSE-17</executionEnvironment>
+          <executionEnvironment>JavaSE-21</executionEnvironment>
           <resolver>p2</resolver>
           <pomDependencies>consider</pomDependencies>
           <ignoreTychoRepositories>true</ignoreTychoRepositories>


### PR DESCRIPTION
- The project now needs JDK21 to properly build. I haven't been able to find a similar package to the _JDK17 + Maven_ one that we were using, and all JDK21 packages that I found were JREs and not JDKs, so I have installed it manually.
- Also, `java.lang` is a default package in Java and never imported. In order to match on the FQNs of annotations, we use the import list, but in this case that doesn't work. Added some conditions to make it a special case.