### PR TITLE
:bug: Make compilation unit consistant with underlying resource

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SymbolInformationTypeRequestor.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SymbolInformationTypeRequestor.java
@@ -73,7 +73,7 @@ public class SymbolInformationTypeRequestor extends SearchRequestor {
 
         }
 
-        SymbolProvider symbolProvider = resolver.resolve(this.symbolKind);
+        SymbolProvider symbolProvider = resolver.resolve(this.symbolKind).get();
         if (symbolProvider instanceof WithQuery) {
             ((WithQuery) symbolProvider).setQuery(this.query);
         }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -36,8 +36,8 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
             symbol.setName(e.getElementName());
             symbol.setKind(convertSymbolKind(e));
             symbol.setContainerName(e.getParent().getElementName());
-            symbol.setLocation(location);
-            if (this.query.contains(".")) {
+            symbol.setLocation(location); 
+            if (this.query.contains(".")) { 
                 ICompilationUnit unit = e.getCompilationUnit();
                 if (unit == null) {
                     IClassFile cls = (IClassFile) ((IJavaElement) e).getAncestor(IJavaElement.CLASS_FILE);

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -187,6 +187,12 @@ public interface SymbolProvider {
      * we do this so that we can rule out a lot of matches before going the AST route
      */
     default boolean queryQualificationMatches(String query, ICompilationUnit unit, Location location) {
+        // Make sure that the ICompilationUnit is conistant
+        try {
+            unit.makeConsistent(null);
+        } catch(Exception e) {
+            logInfo("unable to make unit consistant, will still try as could be class file in a jar" + e);
+        }
         query = query.replaceAll("(?<!\\.)\\*", ".*");
         String queryQualification = "";
         int dotIndex = query.lastIndexOf('.');
@@ -200,9 +206,8 @@ public interface SymbolProvider {
             // for a query, java.io.paths.File*, queryQualification is java.io.paths
             packageQueryQualification = queryQualification.substring(0, packageDotIndex);
         }
-
         // check if the match was found in the same package as the query was looking for
-        if (queryQualification != "" && location.getUri().contains(queryQualification.replaceAll(".", "/"))) {
+        if (queryQualification != "" && location.getUri().contains(queryQualification.replaceAll("\\.", "/"))) {
             return true;
         }
         if (unit != null) {

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProviderResolver.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProviderResolver.java
@@ -3,29 +3,30 @@ package io.konveyor.tackle.core.internal.symbol;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class SymbolProviderResolver {
-    private Map<Integer, SymbolProvider> map;
+    private Map<Integer, Supplier<SymbolProvider>> map;
 
     public SymbolProviderResolver() {
         map = new HashMap<>();
-        map.put(1, new InheritanceSymbolProvider());
-        map.put(2, new MethodCallSymbolProvider());
-        map.put(3, new ConstructorCallSymbolProvider());
-        map.put(4, new AnnotationSymbolProvider());
-        map.put(5, new ImplementsTypeSymbolProvider());
-        map.put(6, new DefaultSymbolProvider());
-        map.put(7, new ReturnTypeSymbolProvider());
-        map.put(8, new ImportSymbolProvider());
-        map.put(9, new VariableDeclarationSymbolProvider());
-        map.put(10, new TypeSymbolProvider());
-        map.put(11, new ReferenceSymbolProvider());
-        map.put(12, new FieldSymbolProvider());
-        map.put(13, new MethodDeclarationSymbolProvider());
-        map.put(14, new ClassDeclarationSymbolProvider());
+        map.put(1, InheritanceSymbolProvider::new);
+        map.put(2, MethodCallSymbolProvider::new);
+        map.put(3, ConstructorCallSymbolProvider::new);
+        map.put(4, AnnotationSymbolProvider::new);
+        map.put(5, ImplementsTypeSymbolProvider::new);
+        map.put(6, DefaultSymbolProvider::new);
+        map.put(7, ReturnTypeSymbolProvider::new);
+        map.put(8, ImportSymbolProvider::new);
+        map.put(9, VariableDeclarationSymbolProvider::new);
+        map.put(10, TypeSymbolProvider::new);
+        map.put(11, ReferenceSymbolProvider::new);
+        map.put(12, FieldSymbolProvider::new);
+        map.put(13, MethodDeclarationSymbolProvider::new);
+        map.put(14, ClassDeclarationSymbolProvider::new);
     }
 
-    public SymbolProvider resolve(Integer i) {
-        return Optional.ofNullable(this.map.get(i)).orElse(new DefaultSymbolProvider());
+    public Supplier<SymbolProvider> resolve(Integer i) {
+        return Optional.ofNullable(this.map.get(i)).orElse(DefaultSymbolProvider::new);
     }
 }


### PR DESCRIPTION
* We need to make sure that the compilation unit is consistant with the underlying resource before we look for the location.
* Changes to the filesystem are reflected correctly in the search match, but are not reflected in the compilation unit, so we need to force it to become consistant.
* Fixed a bug in a regex replace that caused every char to be changed to "/"
* Fixed a potential bug, where for a multipattern seach match, we could have overwrites of the specific SymbolProvider.

fixes #122 