### PR TITLE
:bug: closing the compilation unit is needed for make consistant to work

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -5,7 +5,7 @@ on: ["push", "pull_request", "workflow_dispatch"]
 jobs:
   build-addon:
     name: Build tackle2-addon-analyzer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       api_tests_ref: ${{ steps.extract_info.outputs.API_TESTS_REF }}
     strategy:

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -63,6 +63,7 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                         symbols.add(symbol);
                     }
                 }
+                unit.close();
             } else {
                 symbols.add(symbol);
             }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -56,6 +56,7 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                         symbols.add(symbol);
                     }
                 }
+                unit.close();
             } else {
                 symbols.add(symbol);
             }


### PR DESCRIPTION
follow on for #123 to make the function work you have to close the working copy after you use it.