### PR TITLE
Close compilation units, do not use deprecated members, fix deps

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -49,7 +49,7 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                 if (unit == null) {
                     IClassFile cls = (IClassFile) ((IJavaElement) mod).getAncestor(IJavaElement.CLASS_FILE);
                     if (cls != null) {
-                        unit = cls.becomeWorkingCopy(null, null, null);
+                        unit = cls.getWorkingCopy(new WorkingCopyOwnerImpl(), null);
                     }
                 }
                 if (this.queryQualificationMatches(this.query, unit, location)) {
@@ -63,6 +63,7 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                         symbols.add(symbol);
                     }
                 }
+                unit.discardWorkingCopy();
                 unit.close();
             } else {
                 symbols.add(symbol);

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -9,6 +9,7 @@ import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -42,7 +43,7 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                 if (unit == null) {
                     IClassFile cls = (IClassFile) ((IJavaElement) e).getAncestor(IJavaElement.CLASS_FILE);
                     if (cls != null) {
-                        unit = cls.becomeWorkingCopy(null, null, null);
+                        unit = cls.getWorkingCopy(new WorkingCopyOwnerImpl(), null);
                     }
                 }
                 if (this.queryQualificationMatches(this.query, unit, location)) {
@@ -56,6 +57,7 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                         symbols.add(symbol);
                     }
                 }
+                unit.discardWorkingCopy();
                 unit.close();
             } else {
                 symbols.add(symbol);

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/TypeSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/TypeSymbolProvider.java
@@ -67,7 +67,8 @@ public class TypeSymbolProvider implements SymbolProvider, WithQuery, WithAnnota
                     IClassFile cls = (IClassFile) element.getAncestor(IJavaElement.CLASS_FILE);
                     if (cls != null) {
                         // TODO: make sure following doesn't affect performance
-                        compilationUnit = cls.becomeWorkingCopy(null, null, null);
+                        // compilationUnit = cls.becomeWorkingCopy(null, null, null);
+                        compilationUnit = cls.getWorkingCopy(new WorkingCopyOwnerImpl(), null);
                     }
                 }
                 boolean isAccurate = false;
@@ -100,6 +101,8 @@ public class TypeSymbolProvider implements SymbolProvider, WithQuery, WithAnnota
                         }
                     }
                 }
+                compilationUnit.discardWorkingCopy();
+                compilationUnit.close();
                 if (!isAccurate) {
                     return null;
                 }

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/WorkingCopyOwnerImpl.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/WorkingCopyOwnerImpl.java
@@ -1,0 +1,7 @@
+package io.konveyor.tackle.core.internal.symbol;
+
+import org.eclipse.jdt.core.WorkingCopyOwner;
+
+public class WorkingCopyOwnerImpl extends WorkingCopyOwner {
+    
+}

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -38,6 +38,9 @@
             <unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
             <repository location="https://download.eclipse.org/buildship/updates/e423/snapshots/3.x/3.1.7.v20221108-1729-s/"/>
         </location>
+        <!-- <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit"> -->
+            <!-- <repository location="https://download.eclipse.org/releases/2024-03/"/> -->
+        <!-- </location> -->
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
@@ -65,7 +68,7 @@
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
+            <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.34.0/"/>
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
         </location>
     </locations>


### PR DESCRIPTION
- Update code to remove usage of deprecated method call.
- Close compilation units properly when not using them anymore.
- Update dependency due to broken build.

https://issues.redhat.com/browse/MTA-4943