### PR TITLE
Improve false positive in METHOD_CALL and CONSTRUCTOR_CALL

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -10,6 +10,7 @@ import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -58,6 +59,11 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                     astParser.setResolveBindings(true);
                     CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
                     CustomASTVisitor visitor = new CustomASTVisitor(query, match, QueryLocation.CONSTRUCTOR_CALL);
+                    // Under test, resolveConstructorBinding will return null if there are problems
+                    IProblem[] problems = cu.getProblems();
+                    if (problems != null && problems.length > 0) {
+                        logInfo("KONVEYOR_LOG: " + "Found " + problems.length + " problems while compiling");
+                    }
                     cu.accept(visitor);
                     if (visitor.symbolMatches()) {
                         symbols.add(symbol);

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -63,6 +63,15 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                     IProblem[] problems = cu.getProblems();
                     if (problems != null && problems.length > 0) {
                         logInfo("KONVEYOR_LOG: " + "Found " + problems.length + " problems while compiling");
+                        int count = 0;
+                        for (IProblem problem : problems) {
+                            logInfo("KONVEYOR_LOG: Problem - ID: " + problem.getID() + " Message: " + problem.getMessage());
+                            count++;
+                            if (count >= SymbolProvider.MAX_PROBLEMS_TO_LOG) {
+                                logInfo("KONVEYOR_LOG: Only showing first " + SymbolProvider.MAX_PROBLEMS_TO_LOG + " problems, " + (problems.length - SymbolProvider.MAX_PROBLEMS_TO_LOG) + " more not displayed");
+                                break;
+                            }
+                        }
                     }
                     cu.accept(visitor);
                     if (visitor.symbolMatches()) {

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/ConstructorCallSymbolProvider.java
@@ -59,7 +59,7 @@ public class ConstructorCallSymbolProvider implements SymbolProvider, WithQuery 
                     astParser.setResolveBindings(true);
                     CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
                     CustomASTVisitor visitor = new CustomASTVisitor(query, match, QueryLocation.CONSTRUCTOR_CALL);
-                    // Under test, resolveConstructorBinding will return null if there are problems
+                    // Under tests, resolveConstructorBinding will return null if there are problems
                     IProblem[] problems = cu.getProblems();
                     if (problems != null && problems.length > 0) {
                         logInfo("KONVEYOR_LOG: " + "Found " + problems.length + " problems while compiling");

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -10,6 +10,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -52,6 +53,11 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                     astParser.setResolveBindings(true);
                     CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
                     CustomASTVisitor visitor = new CustomASTVisitor(query, match, QueryLocation.METHOD_CALL);
+                    // Under test, resolveConstructorBinding will return null if there are problems
+                    IProblem[] problems = cu.getProblems();
+                    if (problems != null && problems.length > 0) {
+                        logInfo("KONVEYOR_LOG: " + "Found " + problems.length + " problems while compiling");
+                    }
                     cu.accept(visitor);
                     if (visitor.symbolMatches()) {
                         symbols.add(symbol);

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -53,7 +53,7 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                     astParser.setResolveBindings(true);
                     CompilationUnit cu = (CompilationUnit) astParser.createAST(null);
                     CustomASTVisitor visitor = new CustomASTVisitor(query, match, QueryLocation.METHOD_CALL);
-                    // Under test, resolveConstructorBinding will return null if there are problems
+                    // Under tests, resolveConstructorBinding will return null if there are problems
                     IProblem[] problems = cu.getProblems();
                     if (problems != null && problems.length > 0) {
                         logInfo("KONVEYOR_LOG: " + "Found " + problems.length + " problems while compiling");

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/MethodCallSymbolProvider.java
@@ -57,6 +57,16 @@ public class MethodCallSymbolProvider implements SymbolProvider, WithQuery {
                     IProblem[] problems = cu.getProblems();
                     if (problems != null && problems.length > 0) {
                         logInfo("KONVEYOR_LOG: " + "Found " + problems.length + " problems while compiling");
+                        int count = 0;
+                        for (IProblem problem : problems) {
+                            logInfo("KONVEYOR_LOG: Problem - ID: " + problem.getID() + " Message: " + problem.getMessage());
+                            count++;
+                            if (count >= SymbolProvider.MAX_PROBLEMS_TO_LOG) {
+                                logInfo("KONVEYOR_LOG: Only showing first " + SymbolProvider.MAX_PROBLEMS_TO_LOG + " problems, " +
+                                       (problems.length - SymbolProvider.MAX_PROBLEMS_TO_LOG) + " more not displayed");
+                                break;
+                            }
+                        }
                     }
                     cu.accept(visitor);
                     if (visitor.symbolMatches()) {

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -30,6 +30,8 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 public interface SymbolProvider {
+    public static final int MAX_PROBLEMS_TO_LOG = 10;
+
     List<SymbolInformation> get(SearchMatch match) throws CoreException;
 
     default SymbolKind convertSymbolKind(IJavaElement element) {
@@ -195,7 +197,8 @@ public interface SymbolProvider {
         }
         // should consider parameter here
         // e.g. java.nio.file.Paths.get(String)/java.nio.file.Paths.get(*)  -> java.nio.file.Paths.get
-        query = query.replaceAll("\\([^\\)]*\\)", "");
+        // Remove any parentheses and their contents
+        query = query.replaceAll("\\(.*\\)", "");
         query = query.replaceAll("(?<!\\.)\\*", ".*");
         String queryQualification = "";
         int dotIndex = query.lastIndexOf('.');

--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java
@@ -193,6 +193,9 @@ public interface SymbolProvider {
         } catch(Exception e) {
             logInfo("unable to make unit consistant, will still try as could be class file in a jar" + e);
         }
+        // should consider parameter here
+        // e.g. java.nio.file.Paths.get(String)/java.nio.file.Paths.get(*)  -> java.nio.file.Paths.get
+        query = query.replaceAll("\\([^\\)]*\\)", "");
         query = query.replaceAll("(?<!\\.)\\*", ".*");
         String queryQualification = "";
         int dotIndex = query.lastIndexOf('.');
@@ -221,9 +224,9 @@ public interface SymbolProvider {
                 for (IImportDeclaration importDecl : unit.getImports()) {
                     String importElement = importDecl.getElementName();
                     String importQualification = "";
-                    int importDotIndex = query.lastIndexOf('.');
+                    int importDotIndex = importElement.lastIndexOf('.');
                     if (importDotIndex > 0) {
-                        importQualification = query.substring(0, dotIndex);
+                        importQualification = importElement.substring(0, importDotIndex);
                     }
                     // import can be absolute like java.io.paths.FileReader
                     if (query.matches(importElement)) {
@@ -236,16 +239,18 @@ public interface SymbolProvider {
                     if (importElement.contains("*")) {                     
                         if (queryQualification != "") {
                             // query is java.io.paths.File*, import is java.io.paths.*
-                            if (queryQualification.startsWith(importQualification)) {
+                            if (queryQualification.equals(importQualification) ||
+                                queryQualification.startsWith(importQualification + ".")) {
                                 return true;
                             }
-                            if (importElement.replaceAll(".*", "").matches(queryQualification)) {
+                            String importWithoutWildcard = importElement.replace(".*", "");
+                            if (importWithoutWildcard.equals(queryQualification)) {
                                 return true;
                             }
                         }
                     }
-                    // query can be java.io.paths.Path.checkPath()
-                    if (query.startsWith(importElement)) {
+                    //import can be java.nio.file.Path, query can be java.nio.file.Paths.get*
+                    if (query.equals(importElement) || query.startsWith(importElement + ".")) {
                         return true;
                     }
                 }


### PR DESCRIPTION
This is the fix for https://github.com/konveyor/analyzer-lsp/issues/827
Fix following three error:
1. [This line](https://github.com/konveyor/java-analyzer-bundle/blob/32f19a14a3ada831f62939f62ea7ec9316f3355a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java#L196C9-L196C55) will behave unexpected if the pattern includes parameter, e.g. `java.nio.file.Paths.get(*)` will become `java.nio.file.Paths.get(.*)`
2. [importQualification](https://github.com/konveyor/java-analyzer-bundle/blob/32f19a14a3ada831f62939f62ea7ec9316f3355a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java#L224C21-L227C22) should come from`importElement` instead of `query`, otherwise this [condition](https://github.com/konveyor/java-analyzer-bundle/blob/32f19a14a3ada831f62939f62ea7ec9316f3355a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java#L239C63-L239C82) will return true incorrectly
3. `importElement.replaceAll(".*", "")` will always return empty string, make this [condition](https://github.com/konveyor/java-analyzer-bundle/blob/32f19a14a3ada831f62939f62ea7ec9316f3355a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/SymbolProvider.java#L242C29-L242C96) always return false, use `importElement.replace(".*", "")` instead

And other improvements for some corner case