### PR TITLE
make sure subdirectories are correctly added to search scopes

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SampleDelegateCommandHandler.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SampleDelegateCommandHandler.java
@@ -235,7 +235,20 @@ public class SampleDelegateCommandHandler implements IDelegateCommandHandler {
                     IPath includedIPath = Path.fromOSString(includedPath);
                     if (includedIPath.isAbsolute()) {
                         includedIPath = includedIPath.makeRelativeTo(workspaceDirectoryLocation.iterator().next());
-                        // we need to remove the /src/java from the path
+                        // when the java project is in a sub-directory, we need to cut everything
+                        // until the first occurrence of "src".
+                        if (!includedIPath.segment(0).equals("src")) {
+                            int srcSegmentIdx = -1;
+                            for (int i = 0; i < includedIPath.segmentCount(); i += 1) {
+                                if (includedIPath.segment(i).equals("src")) {
+                                    srcSegmentIdx = i;
+                                }
+                            }
+                            if (srcSegmentIdx != -1) {
+                                includedIPath = includedIPath.removeFirstSegments(srcSegmentIdx);
+                            }
+                        }
+                        // we need to remove the /src/main/java from the path
                         if (includedIPath.segment(0).equals("src")) {
                             includedIPath = includedIPath.removeFirstSegments(1);
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of Java elements when projects are in nested workspace directories by normalizing absolute include paths.
  * Increased reliability when locating classes and source files, reducing failures when opening or navigating to code from absolute paths.
  * Enhances accuracy of element lookup across varied project structures (e.g., paths containing src/main/java), leading to more consistent navigation and analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->