### PR TITLE
:bug: Set symbol kind as Module so that is not filtered out later in the analyzer

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SampleDelegateCommandHandler.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/SampleDelegateCommandHandler.java
@@ -386,7 +386,7 @@ public class SampleDelegateCommandHandler implements IDelegateCommandHandler {
                             if (regex.matcher(imp.getName().getFullyQualifiedName()).matches()) {
                                 SymbolInformation symbol = new SymbolInformation();
                                 symbol.setName(imp.getName().getFullyQualifiedName());
-                                symbol.setKind(SymbolKind.Namespace);
+                                symbol.setKind(SymbolKind.Module);
                                 symbol.setContainerName(unit.getElementName());
                                 symbol.setLocation(getLocationForImport(unit, imp, cu));
                                 System.out.println("Found in " + unit.getElementName());


### PR DESCRIPTION
See [this line](https://github.com/konveyor/analyzer-lsp/blob/7d8b3218997f3086c02e141a431c37de8b232df2/external-providers/java-external-provider/pkg/java_external_provider/filter.go#L41) in the analyzer-lsp project.

https://issues.redhat.com/browse/MTA-5387

API tests PR: 343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed symbol classification for on-demand import matches in code analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->