### PR TITLE
:bug: removing idx file as we no longer need it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bu
 COPY --from=fernflower /output/fernflower.jar /bin/fernflower.jar
 COPY --from=maven-index /maven.default.index /usr/local/etc/maven.default.index
 COPY --from=index-download /maven-index-data/central.archive-metadata.txt /usr/local/etc/maven-index.txt
-COPY --from=index-download /maven-index-data/central.archive-metadata.idx /usr/local/etc/maven-index.idx
 
 RUN ln -sf /root/.m2 /.m2 && chgrp -R 0 /root && chmod -R g=u /root
 CMD [ "/jdtls/bin/jdtls" ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration. Maven index metadata is no longer included in the final image, which may affect Maven-based dependency resolution in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->