### PR TITLE
fix: Strip parameter types from METHOD_CALL patterns

### DIFF
--- a/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/CustomASTVisitor.java
+++ b/java-analyzer-bundle.core/src/main/java/io/konveyor/tackle/core/internal/symbol/CustomASTVisitor.java
@@ -42,11 +42,19 @@ public class CustomASTVisitor extends ASTVisitor {
 
     public CustomASTVisitor(String query, SearchMatch match, QueryLocation location) {
         /*
+         * Strip parameter types from the query pattern before matching
+         * The AST provides method names without parameter types, but users
+         * may specify patterns like "ClassName.method(ParamType1, ParamType2)"
+         * We need to remove the parameter types to match correctly
+         */
+        String processedQuery = query.replaceAll("\\([^)]*\\)", "");
+
+        /*
          * When comparing query pattern with an actual java element's fqn
          * we need to make sure that * not preceded with a . are replaced
          * by .* so that java regex works as expected on them
         */
-        this.query = query.replaceAll("(?<!\\.)\\*", ".*");
+        this.query = processedQuery.replaceAll("(?<!\\.)\\*", ".*");
         this.symbolMatches = false;
         this.match = match;
         // depending on which location the query was for we only want to


### PR DESCRIPTION
## Description

Fixes konveyor/analyzer-lsp#854

This PR fixes a bug where METHOD_CALL rules with patterns containing parameter types (e.g., `java.util.Properties.setProperty(java.lang.String, java.lang.String)`) fail to match actual method calls.

## Problem

When users specify METHOD_CALL patterns with parameter types, the `CustomASTVisitor` was failing to match these patterns because:

1. The AST resolves method names as `ClassName.methodName` without parameter types
2. The query pattern still contained parameter types like `(Type1, Type2)`
3. The regex match would fail due to this mismatch

## Solution

Added preprocessing in the `CustomASTVisitor` constructor to strip parameter types (everything within parentheses) from the query pattern before applying other transformations. This allows patterns with parameter types to match correctly against the AST-resolved method names.

## Example

- **Input pattern**: `java.util.Properties.setProperty(java.lang.String, java.lang.String)`
- **Processed pattern**: `java.util.Properties.setProperty`
- **AST method name**: `java.util.Properties.setProperty`
- **Result**: ✅ Match successful

## Test Case

The issue can be reproduced with the following rule against the `examples/customers-tomcat-legacy` project in analyzer-lsp:

```yaml
- message: "Found usage of java.util.Properties.setProperty method"
  ruleID: test-setproperty-00001
  when:
    java.referenced:
      location: METHOD_CALL
      pattern: java.util.Properties.setProperty(java.lang.String, java.lang.String)
```

This rule should trigger on lines 68-70 in `src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java` but previously did not.

## Changes

- Modified `CustomASTVisitor.java` constructor to strip parameter types using regex `\([^)]*\)` before other query transformations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol query matching for methods, constructors, and annotations. Queries that include parameter type information are now processed with enhanced accuracy. This results in more precise pattern matching while preserving backward compatibility with existing queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->