### PR TITLE
:bug: Bring idx file too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bu
 COPY --from=fernflower /output/fernflower.jar /bin/fernflower.jar
 COPY --from=maven-index /maven.default.index /usr/local/etc/maven.default.index
 COPY --from=index-download /maven-index-data/central.archive-metadata.txt /usr/local/etc/maven-index.txt
+COPY --from=index-download /maven-index-data/central.archive-metadata.idx /usr/local/etc/maven-index.idx
 
 RUN ln -sf /root/.m2 /.m2 && chgrp -R 0 /root && chmod -R g=u /root
 CMD [ "/jdtls/bin/jdtls" ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Maven index data available in Docker build process with additional metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->