### PR TITLE
:ghost: Adding ability to ask for java provider rebuild after image build

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -36,10 +36,10 @@ jobs:
           application_id: ${{ vars.KONVEYOR_BOT_ID }}
           application_private_key: ${{ secrets.KONVEYOR_BOT_KEY }}
 
-      // Tell the analyzer to re-build it's images to get the update image.
+      # Tell the analyzer to re-build it's images to get the update image.
       - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           repository: "konveyor/analyzer-lsp"
           event-type: rebuild-java-provider
-          client-payload: '{"ref": "${{ github.ref_name }}"}'
+          client-payload: '{"ref": "${{ github.ref}}", "ref_name": "${{ github.ref_name }}"}'


### PR DESCRIPTION
Currently, we have to manually do this, to take any changes from this base image, and this has led to many issues with debugging CI. Automatically doing this, will help keeps things sane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow job to GitHub Actions that triggers coordinated image rebuilds across related repositories using token-based repository dispatch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->