### PR TITLE
Adding real versions to the artifact during build in the workflows 

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -18,13 +18,63 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  determine-version:
+    name: Determine Bundle Version
+    runs-on: ubuntu-latest
+    outputs:
+      bundle_version: ${{ steps.version.outputs.bundle_version }}
+      is_release: ${{ steps.version.outputs.is_release }}
+    steps:
+      - name: Determine version from git ref
+        id: version
+        run: |
+          # Translate upstream 0.x tags to downstream 1.x artifact versions.
+          # Anchor: v0.9.1 == 1.0.0
+          #   0.9.P  (P>=1) -> 1.0.(P-1)
+          #   0.M.P  (M>=10) -> 1.(M-9).P
+          #   1.x.y+         -> pass-through
+          translate_version() {
+            local raw="$1" base suffix=""
+            # Separate pre-release suffix (e.g., -rc.1, -alpha.2)
+            if [[ "$raw" == *-* ]]; then
+              suffix="-${raw#*-}"
+              base="${raw%%-*}"
+            else
+              base="$raw"
+            fi
+            IFS='.' read -r major minor patch <<< "$base"
+            if [[ "$major" -ge 1 ]]; then
+              echo "${base}${suffix}"
+            elif [[ "$minor" -ge 10 ]]; then
+              echo "1.$((minor - 9)).${patch}${suffix}"
+            elif [[ "$minor" -eq 9 && "$patch" -ge 1 ]]; then
+              echo "1.0.$((patch - 1))${suffix}"
+            else
+              echo "${base}${suffix}"
+            fi
+          }
+
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            RAW_VERSION="${GITHUB_REF#refs/tags/v}"
+            VERSION=$(translate_version "$RAW_VERSION")
+            echo "bundle_version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "Tag: v${RAW_VERSION} -> artifact version: ${VERSION}"
+          else
+            echo "bundle_version=1.1.0-SNAPSHOT" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "Building SNAPSHOT version: 1.1.0-SNAPSHOT"
+          fi
+
   image-build:
+    needs: determine-version
     uses: konveyor/release-tools/.github/workflows/build-push-images.yaml@main
     with:
       registry: "quay.io/konveyor"
       image_name: "jdtls-server-base"
       containerfile: "./Dockerfile"
       architectures: '[ "amd64", "arm64" ]'
+      extra-args: "--build-arg BUNDLE_VERSION=${{ needs.determine-version.outputs.bundle_version }}"
       publish: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
@@ -33,7 +83,7 @@ jobs:
   build_image_analyzer:
     name: trigger java provider rebuild
     runs-on: ubuntu-latest
-    needs: image-build
+    needs: [determine-version, image-build]
     if: github.event_name == 'push'
     steps:
       - name: Get Token
@@ -43,10 +93,10 @@ jobs:
           application_id: ${{ vars.KONVEYOR_BOT_ID }}
           application_private_key: ${{ secrets.KONVEYOR_BOT_KEY }}
 
-      # Tell the analyzer to re-build it's images to get the update image.
+      # Tell the analyzer to re-build its images to get the updated image.
       - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           repository: "konveyor/analyzer-lsp"
           event-type: rebuild-java-provider
-          client-payload: '{"ref": "${{ github.ref}}", "ref_name": "${{ github.ref_name }}"}'
+          client-payload: '{"ref": "${{ github.ref }}", "ref_name": "${{ github.ref_name }}", "bundle_version": "${{ needs.determine-version.outputs.bundle_version }}"}'

--- a/.github/workflows/post-release-bump.yaml
+++ b/.github/workflows/post-release-bump.yaml
@@ -1,0 +1,116 @@
+name: Post-Release Version Bump
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  bump-version:
+    name: Bump to next SNAPSHOT version
+    runs-on: ubuntu-latest
+    # Only bump for final releases (skip pre-releases like v0.9.2-rc.1)
+    if: ${{ !contains(github.ref_name, '-') }}
+
+    steps:
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
+        with:
+          application_id: ${{ vars.KONVEYOR_BOT_ID }}
+          application_private_key: ${{ secrets.KONVEYOR_BOT_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.get_workflow_token.outputs.token }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Calculate next version
+        id: next_version
+        run: |
+          # Same translation logic as image-build.yaml
+          # Anchor: v0.9.1 == 1.0.0
+          translate_version() {
+            local raw="$1" base
+            IFS='.' read -r major minor patch <<< "$raw"
+            if [[ "$major" -ge 1 ]]; then
+              echo "${raw}"
+            elif [[ "$minor" -ge 10 ]]; then
+              echo "1.$((minor - 9)).${patch}"
+            elif [[ "$minor" -eq 9 && "$patch" -ge 1 ]]; then
+              echo "1.0.$((patch - 1))"
+            else
+              echo "${raw}"
+            fi
+          }
+
+          RAW_VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE_VERSION=$(translate_version "$RAW_VERSION")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_VERSION"
+          NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0-SNAPSHOT"
+
+          echo "raw_version=${RAW_VERSION}" >> $GITHUB_OUTPUT
+          echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
+          echo "Tag: v${RAW_VERSION} -> released: ${RELEASE_VERSION} -> next dev: ${NEXT_VERSION}"
+
+      - name: Set next SNAPSHOT version in POMs and MANIFESTs
+        run: |
+          mvn -B org.eclipse.tycho:tycho-versions-plugin:4.0.7:set-version \
+            -DnewVersion=${{ steps.next_version.outputs.next_version }}
+
+      - name: Update Dockerfile ARG defaults
+        run: |
+          NEXT="${{ steps.next_version.outputs.next_version }}"
+          sed -i "s/^ARG BUNDLE_VERSION=.*/ARG BUNDLE_VERSION=${NEXT}/" Dockerfile Dockerfile.test
+
+      - name: Configure git
+        run: |
+          git config user.name "konveyor-bot[bot]"
+          git config user.email "konveyor-bot[bot]@users.noreply.github.com"
+
+      - name: Create branch and commit
+        run: |
+          NEXT="${{ steps.next_version.outputs.next_version }}"
+          BRANCH="chore/bump-version-${NEXT}"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit --signoff \
+            -m "chore: bump version to ${NEXT} after ${{ github.ref_name }} release"
+          git push origin "$BRANCH"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+        run: |
+          RAW="${{ steps.next_version.outputs.raw_version }}"
+          RELEASE="${{ steps.next_version.outputs.release_version }}"
+          NEXT="${{ steps.next_version.outputs.next_version }}"
+          gh pr create \
+            --title "chore: bump version to ${NEXT}" \
+            --body "$(cat <<EOF
+          ## Post-Release Version Bump
+
+          Automated version bump after the **${{ github.ref_name }}** release.
+
+          - Upstream tag: \`v${RAW}\`
+          - Artifact version: \`${RELEASE}\`
+          - Next development version: \`${NEXT}\`
+
+          ### Changes
+          - Updated all POM versions via \`tycho-versions:set-version\`
+          - Updated MANIFEST.MF Bundle-Version (qualifier)
+          - Updated Dockerfile ARG defaults
+
+          _This PR was automatically created by the post-release version bump workflow._
+          EOF
+          )" \
+            --base main \
+            --head "chore/bump-version-${NEXT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN ./gradlew build -x test && rm -rf /root/.gradle
 RUN mkdir /output && cp ./build/libs/fernflower.jar /output
 
 FROM registry.access.redhat.com/ubi9/ubi AS addon-build
+ARG BUNDLE_VERSION=1.1.0-SNAPSHOT
 RUN dnf install -y java-21-openjdk-devel wget zip --nodocs --setopt=install_weak_deps=0 && dnf clean all && rm -rf /var/cache/dnf
 RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/local/ && \
@@ -22,7 +23,15 @@ RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-
 WORKDIR /app
 COPY ./ /app/
 ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk
-RUN /usr/local/apache-maven-3.9.14/bin/mvn clean install -DskipTests=true
+# For release builds (non-SNAPSHOT), update all POM and MANIFEST.MF versions via Tycho.
+# NOTE: The Tycho plugin version here must match <tycho.version> in pom.xml.
+RUN case "$BUNDLE_VERSION" in \
+      *-SNAPSHOT) echo "SNAPSHOT build: $BUNDLE_VERSION" ;; \
+      *) echo "Setting release version: $BUNDLE_VERSION"; \
+         /usr/local/apache-maven-3.9.14/bin/mvn -B org.eclipse.tycho:tycho-versions-plugin:4.0.7:set-version \
+           -DnewVersion=$BUNDLE_VERSION ;; \
+    esac
+RUN /usr/local/apache-maven-3.9.14/bin/mvn -B clean install -DskipTests=true
 # Download maven index data
 WORKDIR /maven-index-data
 RUN set -e; \
@@ -56,8 +65,9 @@ COPY hack/maven.default.index /usr/local/etc/maven.default.index
 COPY --from=jdtls-download /jdtls /jdtls/
 COPY --from=addon-build /usr/local/apache-maven-3.9.14/ /usr/local/apache-maven-3.9.14/
 RUN ln -s /usr/local/apache-maven-3.9.14/bin/mvn /usr/bin/mvn
-COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/1.0.0-SNAPSHOT/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/plugins/
-COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/1.0.0-SNAPSHOT/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar
+ARG BUNDLE_VERSION=1.1.0-SNAPSHOT
+COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/${BUNDLE_VERSION}/java-analyzer-bundle.core-${BUNDLE_VERSION}.jar /jdtls/plugins/
+COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/${BUNDLE_VERSION}/java-analyzer-bundle.core-${BUNDLE_VERSION}.jar /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-${BUNDLE_VERSION}.jar
 COPY --from=fernflower /output/fernflower.jar /bin/fernflower.jar
 COPY --from=addon-build /maven-index-data/central.archive-metadata.txt /usr/local/etc/maven-index.txt
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -49,5 +49,6 @@ COPY --from=index-download /maven-index-data/central.archive-metadata.idx /usr/l
 RUN microdnf install -y golang
 
 RUN ln -sf /root/.m2 /.m2 && chgrp -R 0 /root && chmod -R g=u /root
-COPY   java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/plugins/
+ARG BUNDLE_VERSION=1.1.0-SNAPSHOT
+COPY java-analyzer-bundle.core/target/java-analyzer-bundle.core-${BUNDLE_VERSION}.jar /jdtls/plugins/
 CMD [ "/jdtls/bin/jdtls" ]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Java Analyzer Bundle
 # Replicates GitHub Actions CI/CD pipeline for local verification
 
-.PHONY: help all ci clean clean-containers clean-go phase1 phase2 unit-tests build-container run-integration-tests
+.PHONY: help all ci clean clean-containers clean-go phase1 phase2 unit-tests build-container run-integration-tests set-version
 
 # Detect container runtime (prefer Podman, fallback to Docker)
 CONTAINER_RUNTIME := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -20,6 +20,8 @@ endif
 IMAGE_NAME := jdtls-analyzer:test
 REPO_ROOT := $(shell pwd)
 GO_MODULE := java-analyzer-bundle.test/integration
+BUNDLE_VERSION ?= 1.1.0-SNAPSHOT
+TYCHO_VERSION := 4.0.7
 
 # Default target
 help:
@@ -40,10 +42,18 @@ help:
 	@echo "  make build-container     - Build JDT.LS container image"
 	@echo "  make run-integration-tests - Run integration tests in container"
 	@echo ""
+	@echo "Version targets:"
+	@echo "  make set-version         - Set bundle version (uses BUNDLE_VERSION)"
+	@echo ""
 	@echo "Utility targets:"
 	@echo "  make clean               - Clean all build artifacts"
 	@echo "  make clean-containers    - Remove container images"
 	@echo "  make clean-go            - Clean Go build artifacts"
+	@echo ""
+	@echo "Variables:"
+	@echo "  BUNDLE_VERSION           - Bundle version (default: 1.1.0-SNAPSHOT)"
+	@echo "                             Set to release version for non-SNAPSHOT builds"
+	@echo "                             Example: make ci BUNDLE_VERSION=1.2.0"
 	@echo ""
 	@echo "Container runtime: $(CONTAINER_RUNTIME)"
 	@echo "======================================================================"
@@ -72,10 +82,21 @@ phase2: build-container run-integration-tests
 	@echo "✓ Phase 2 Complete: Integration tests passed"
 	@echo "======================================================================"
 
-# Phase 1 Targets
-unit-tests:
+# Version management
+set-version:
+ifeq ($(findstring -SNAPSHOT,$(BUNDLE_VERSION)),)
 	@echo "======================================================================"
-	@echo "Phase 1: Running Unit Tests"
+	@echo "Setting release version: $(BUNDLE_VERSION)"
+	@echo "======================================================================"
+	mvn -B org.eclipse.tycho:tycho-versions-plugin:$(TYCHO_VERSION):set-version -DnewVersion=$(BUNDLE_VERSION)
+else
+	@echo "Using SNAPSHOT version: $(BUNDLE_VERSION)"
+endif
+
+# Phase 1 Targets
+unit-tests: set-version
+	@echo "======================================================================"
+	@echo "Phase 1: Running Unit Tests (version: $(BUNDLE_VERSION))"
 	@echo "======================================================================"
 	@echo ""
 	mvn clean integration-test
@@ -84,12 +105,12 @@ unit-tests:
 build-container:
 	@echo ""
 	@echo "======================================================================"
-	@echo "Phase 2: Building JDT.LS Container Image"
+	@echo "Phase 2: Building JDT.LS Container Image (version: $(BUNDLE_VERSION))"
 	@echo "======================================================================"
 	@echo ""
 	@echo "Using container runtime: $(CONTAINER_RUNTIME)"
 	@echo ""
-	$(CONTAINER_RUNTIME) build -t $(IMAGE_NAME) -f Dockerfile.test .
+	$(CONTAINER_RUNTIME) build -t $(IMAGE_NAME) -f Dockerfile.test --build-arg BUNDLE_VERSION=$(BUNDLE_VERSION) .
 	@echo ""
 	@echo "✓ Container image built: $(IMAGE_NAME)"
 

--- a/java-analyzer-bundle.core/META-INF/MANIFEST.MF
+++ b/java-analyzer-bundle.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: java-analyzer-bundle Core Extension
 Bundle-SymbolicName: java-analyzer-bundle.core;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Activator: io.konveyor.tackle.core.internal.ExtensionActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.ls.core,

--- a/java-analyzer-bundle.core/pom.xml
+++ b/java-analyzer-bundle.core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>java-analyzer-bundle</artifactId>
     <groupId>io.konveyor.tackle</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>java-analyzer-bundle.core</artifactId>

--- a/java-analyzer-bundle.site/pom.xml
+++ b/java-analyzer-bundle.site/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>java-analyzer-bundle</artifactId>
 		<groupId>io.konveyor.tackle</groupId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-analyzer-bundle.site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/java-analyzer-bundle.test/META-INF/MANIFEST.MF
+++ b/java-analyzer-bundle.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: java-analyzer-bundle Test Fragment
 Bundle-SymbolicName: java-analyzer-bundle.test
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Fragment-Host: java-analyzer-bundle.core;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.jdt.junit4.runtime;bundle-version="1.1.0",

--- a/java-analyzer-bundle.test/README.md
+++ b/java-analyzer-bundle.test/README.md
@@ -16,7 +16,7 @@ make phase2     # Integration tests only
 ### Run Specific Tests
 
 ```bash
-# Maven unit tests (48 tests)
+# Maven unit tests (76 tests)
 mvn clean integration-test
 
 # Go integration tests (specific test)
@@ -31,12 +31,17 @@ This module contains two phases of testing:
 ### Phase 1: Unit Tests (Maven/JUnit)
 **Location**: `src/main/java/`
 **Technology**: JUnit-Plugin (runs in Eclipse environment)
-**Count**: 48 tests
+**Count**: 76 tests
 
-Tests command handling, parameter parsing, and error cases:
+Tests command handling, parameter parsing, AST visitors, symbol providers, and error cases:
 - `RuleEntryParamsTest` (14 tests)
 - `AnnotationQueryTest` (18 tests)
 - `SampleDelegateCommandHandlerTest` (16 tests)
+- `CustomASTVisitorTest` (16 tests)
+- `MethodDeclarationSymbolProviderTest` (8 tests)
+- `CommandHandlerTest` (2 tests)
+- `JavaAnnotationTest` (1 test)
+- `PomDependencyTest` (1 test)
 
 **Run**: `mvn clean integration-test`
 
@@ -132,7 +137,7 @@ Real-world Spring MVC application:
 
 - **Java 17** - Target platform and tests
 - **Eclipse Tycho 3.0.1** - Build system
-- **JDT.LS 1.35.0** - Language server
+- **JDT.LS 1.51.0** - Language server
 - **Go 1.21+** - Integration test framework
 - **Podman/Docker** - Container runtime for CI/CD
 - **JUnit 4** - Unit test framework
@@ -179,7 +184,7 @@ java-analyzer-bundle.test/
   <groupId>org.eclipse.tycho</groupId>
   <artifactId>tycho-surefire-plugin</artifactId>
   <configuration>
-    <useUIHarness>true</useUIHarness>
+    <useUIHarness>false</useUIHarness>
     <useUIThread>false</useUIThread>
   </configuration>
 </plugin>
@@ -193,7 +198,12 @@ java-analyzer-bundle.test/
 
 **Two-Phase Execution**:
 1. **Phase 1**: Maven unit tests (`mvn clean integration-test`)
-2. **Phase 2**: Build container → Go integration tests
+2. **Phase 2**: Build self-contained container (default `Dockerfile`) → Go integration tests
+
+**Container Images**:
+- **CI** uses the default `Dockerfile` which builds the plugin JAR from source inside the container
+- **Local** (`make phase2`) uses `Dockerfile.test` which expects a pre-built JAR on the host
+- Both produce equivalent images with JDT.LS + the analyzer plugin
 
 **Triggers**:
 - Push to `main` or `maven-index` branches
@@ -242,8 +252,9 @@ go test -v -run TestSpecificTest
 
 ### Build Test Container
 ```bash
-# From repository root
-podman build -t jdtls-analyzer:test .
+# From repository root (requires pre-built JAR via mvn install)
+mvn clean install -DskipTests
+podman build -t jdtls-analyzer:test -f Dockerfile.test .
 ```
 
 ---

--- a/java-analyzer-bundle.test/README.md
+++ b/java-analyzer-bundle.test/README.md
@@ -135,10 +135,10 @@ Real-world Spring MVC application:
 
 ## Key Technologies
 
-- **Java 17** - Target platform and tests
-- **Eclipse Tycho 3.0.1** - Build system
+- **Java 21** - Target platform and tests
+- **Eclipse Tycho 4.0.7** - Build system
 - **JDT.LS 1.51.0** - Language server
-- **Go 1.21+** - Integration test framework
+- **Go 1.23+** - Integration test framework
 - **Podman/Docker** - Container runtime for CI/CD
 - **JUnit 4** - Unit test framework
 

--- a/java-analyzer-bundle.test/docs/README.md
+++ b/java-analyzer-bundle.test/docs/README.md
@@ -125,15 +125,20 @@ Detailed overview of the Java test projects:
 
 ## 🧪 Test Structure
 
-### Phase 1: Maven Unit Tests (48 tests)
+### Phase 1: Maven Unit Tests (76 tests)
 **Location**: `../src/main/java/`
 **Framework**: JUnit-Plugin
-**Coverage**: Command handling, parameter parsing, error cases
+**Coverage**: Command handling, parameter parsing, AST visitors, symbol providers, error cases
 
 **Tests**:
 - `RuleEntryParamsTest` (14 tests)
 - `AnnotationQueryTest` (18 tests)
 - `SampleDelegateCommandHandlerTest` (16 tests)
+- `CustomASTVisitorTest` (16 tests)
+- `MethodDeclarationSymbolProviderTest` (8 tests)
+- `CommandHandlerTest` (2 tests)
+- `JavaAnnotationTest` (1 test)
+- `PomDependencyTest` (1 test)
 
 **Run**: `mvn clean integration-test`
 
@@ -171,8 +176,8 @@ Detailed overview of the Java test projects:
 ## 🏗️ Test Projects
 
 ### test-project
-**Purpose**: Systematic coverage of all location types
-**Files**: 8 Java files covering all 15 location types
+**Purpose**: Systematic coverage of all location types + advanced features
+**Files**: 19 Java files covering all 15 location types
 **Key**: `SampleApplication.java` - main test file with comprehensive patterns
 
 ### customers-tomcat-legacy
@@ -200,8 +205,8 @@ make phase2
 cd ../integration
 go test -v -run TestInheritanceSearch
 
-# Build test container
-podman build -t jdtls-analyzer:test ..
+# Build test container (run from repository root, requires pre-built JAR via mvn install)
+cd ../.. && podman build -t jdtls-analyzer:test -f Dockerfile.test .
 
 # Run tests in container
 cd ../integration

--- a/java-analyzer-bundle.test/docs/integration-tests.md
+++ b/java-analyzer-bundle.test/docs/integration-tests.md
@@ -203,7 +203,7 @@ The workflow:
 
 ### Manually (without containers)
 
-Requires JDT.LS 1.51.0+ and Go 1.21+ installed locally:
+Requires JDT.LS 1.51.0+ and Go 1.23+ installed locally:
 
 ```bash
 cd java-analyzer-bundle.test/integration

--- a/java-analyzer-bundle.test/docs/integration-tests.md
+++ b/java-analyzer-bundle.test/docs/integration-tests.md
@@ -21,7 +21,7 @@ Unlike Phase 1 unit tests that only verify commands execute without errors, Phas
 │  ┌────────────────────────────────────────────────┐    │
 │  │           Podman Container                      │    │
 │  │  ┌──────────────────────────────────────────┐      │    │
-│  │  │   JDT.LS Server (1.38.0)             │      │    │
+│  │  │   JDT.LS Server (1.51.0)             │      │    │
 │  │  │   + Java Analyzer Bundle Plugin      │      │    │
 │  │  └──────────────────────────────────────┘      │    │
 │  │         ↕️ LSP over stdio                       │    │
@@ -55,7 +55,8 @@ Go LSP client that communicates with JDT.LS via JSON-RPC 2.0 over stdio using th
 - `Initialize()` - Initialize LSP connection and workspace
 - `ExecuteCommand()` - Execute workspace commands
 - `SearchSymbols()` - Execute analyzer searches via `io.konveyor.tackle.ruleEntry`
-- `Shutdown()` - Gracefully shutdown server
+- `SearchSymbolsWithAnnotation()` - Execute searches with annotation element matching
+- `Shutdown()` / `Close()` - Gracefully shutdown server
 
 **Protocol**: LSP (Language Server Protocol) over stdin/stdout using `jsonrpc2.Connection`
 
@@ -143,9 +144,12 @@ cd java-analyzer-bundle.test/integration
 Or manually with **Podman** (preferred):
 
 ```bash
+# First, build the plugin JAR (required by Dockerfile.test)
+mvn clean install -DskipTests
+
 # Build the container image from repository root
 cd /path/to/java-analyzer-bundle
-podman build -t jdtls-analyzer:test .
+podman build -t jdtls-analyzer:test -f Dockerfile.test .
 
 # Run integration tests with go test
 podman run --rm \
@@ -155,14 +159,17 @@ podman run --rm \
   --workdir /tests/integration \
   --entrypoint /bin/sh \
   jdtls-analyzer:test \
-  -c "microdnf install -y golang && go mod download && go test -v"
+  -c "go mod download && go test -v"
 ```
 
 Or with **Docker**:
 
 ```bash
+# First, build the plugin JAR (required by Dockerfile.test)
+mvn clean install -DskipTests
+
 # Build the Docker image
-docker build -t jdtls-analyzer:test .
+docker build -t jdtls-analyzer:test -f Dockerfile.test .
 
 # Run integration tests with go test
 docker run --rm \
@@ -172,10 +179,12 @@ docker run --rm \
   --workdir /tests/integration \
   --entrypoint /bin/sh \
   jdtls-analyzer:test \
-  -c "microdnf install -y golang && go mod download && go test -v"
+  -c "go mod download && go test -v"
 ```
 
-**Note**: Podman uses `:Z` suffix on volumes for SELinux relabeling. Docker doesn't require this.
+**Notes**:
+- Podman uses `:Z` suffix on volumes for SELinux relabeling. Docker doesn't require this.
+- `Dockerfile.test` requires the plugin JAR to be pre-built on the host (via `mvn install`). It pre-installs golang in the image.
 
 ### Via GitHub Actions
 
@@ -187,12 +196,14 @@ Workflow: `.github/workflows/integration-tests.yml`
 
 The workflow:
 1. Runs Phase 1 unit tests with Maven
-2. Builds the JDT.LS container image with Podman
-3. Runs `go test -v` inside the container
+2. Builds a self-contained container image using the default `Dockerfile` (which builds the plugin JAR from source inside the container)
+3. Installs golang at runtime and runs `go test -v` inside the container
+
+**Note**: CI uses the default `Dockerfile` (self-contained, builds JAR from source). Local development uses `Dockerfile.test` (lighter, expects pre-built JAR). Both produce equivalent images with JDT.LS + the analyzer plugin.
 
 ### Manually (without containers)
 
-Requires JDT.LS 1.38.0 and Go 1.21+ installed locally:
+Requires JDT.LS 1.51.0+ and Go 1.21+ installed locally:
 
 ```bash
 cd java-analyzer-bundle.test/integration
@@ -218,17 +229,17 @@ go test -v -run "TestMethod.*"
 
 ### Default Search (Location 0)
 ```go
-// Search for all List usage across all location types
+// Search for File usage across all location types
 symbols, err := c.SearchSymbols(
     "test-project",
-    "java.util.List",
+    "java.io.File",
     0,  // location type: default (all locations)
     "source-only",
     nil,
 )
 
 // Expected Results:
-// ✓ Finds List in imports, fields, variables, type references, etc.
+// ✓ Finds File in imports, constructors, type references, fields, variables, etc.
 ```
 
 ### Inheritance (Location 1)
@@ -422,7 +433,7 @@ symbols, err := c.SearchSymbols(
     "java.sql.PreparedStatement",
     8,  // location type: import
     "source-only",
-    &includedPaths,
+    includedPaths,
 )
 
 // Expected Results:
@@ -432,118 +443,71 @@ symbols, err := c.SearchSymbols(
 
 ## Test Assertions
 
-Tests verify using helper functions from `tests/test_utils.go`:
+Tests verify using helper functions from `test_helpers.go`:
 
-1. **Symbol Existence**:
+1. **Symbol Existence** (check name, optionally kind):
    ```go
-   if VerifySymbolInResults(symbols, "SampleApplication") {
-       results.AddPass("Test passed")
-   } else {
-       results.AddFail("Test failed", "SampleApplication not found")
+   if !verifySymbolInResults(symbols, "SampleApplication") {
+       t.Errorf("SampleApplication not found in results")
    }
    ```
 
-2. **Symbol Kind**:
+2. **Symbol Location** (check name appears in expected file):
    ```go
-   if VerifySymbolInResults(symbols, "Customer", protocol.Class) {
-       results.AddPass("Test passed")
+   if !verifySymbolLocationContains(symbols, "processData", "SampleApplication") {
+       t.Errorf("processData not found in SampleApplication")
    }
    ```
 
-3. **Symbol Location**:
+3. **Result Count** (verify non-empty results):
    ```go
-   if VerifySymbolLocationContains(symbols, "Customer", "Customer.java") {
-       results.AddPass("Test passed")
+   if len(symbols) == 0 {
+       t.Errorf("Expected symbols but got 0 results")
    }
    ```
 
-4. **Result Count**:
+4. **Container Matching** (check annotation on specific class):
    ```go
-   if count := CountSymbols(symbols); count > 0 {
-       results.AddPass(fmt.Sprintf("Found %d results", count))
+   for _, symbol := range symbols {
+       if symbol.Name == "Entity" && symbol.ContainerName == "Customer" {
+           found = true
+       }
    }
    ```
 
 ## Expected Output
 
+The tests use Go's standard `testing` framework and produce output like:
+
 ```
-============================================================
-Phase 2 Integration Tests - JDT.LS Search Verification
-============================================================
+=== RUN   TestDefaultSearch
+=== RUN   TestDefaultSearch/Find_BaseService_across_all_locations
+=== RUN   TestDefaultSearch/Find_println_across_all_locations
+=== RUN   TestDefaultSearch/Find_File_across_all_locations
+--- PASS: TestDefaultSearch (0.15s)
 
-JDT.LS Path: /jdtls
-Workspace: /tests/projects
+=== RUN   TestInheritanceSearch
+=== RUN   TestInheritanceSearch/Find_SampleApplication_extends_BaseService
+=== RUN   TestInheritanceSearch/Find_DataService_extends_BaseService
+=== RUN   TestInheritanceSearch/Find_CustomException_extends_Exception
+--- PASS: TestInheritanceSearch (0.12s)
 
-Initializing JDT.LS client...
-Started JDT.LS server with PID 1234
-JDT.LS initialized successfully
-JDT.LS ready for testing
+...
 
---- Testing Default Searches (Location 0) ---
-✓ PASS: Default: Find all List usage across all location types
+=== RUN   TestAnnotatedElementMatching
+=== RUN   TestAnnotatedElementMatching/Find_@ActivationConfigProperty_with_propertyName=destinationLookup
+=== RUN   TestAnnotatedElementMatching/Find_@DataSourceDefinition_with_className=org.postgresql.Driver
+=== RUN   TestAnnotatedElementMatching/Find_@DataSourceDefinition_with_className=com.mysql.jdbc.Driver
+=== RUN   TestAnnotatedElementMatching/Find_@Column_with_nullable=false
+--- PASS: TestAnnotatedElementMatching (0.16s)
 
---- Testing Inheritance Searches (Location 1) ---
-✓ PASS: Inheritance: Find SampleApplication extends BaseService
-✓ PASS: Inheritance: Find DataService extends BaseService
-✓ PASS: Inheritance: Find CustomException extends Exception
+=== RUN   TestFilePathFiltering
+=== RUN   TestFilePathFiltering/Find_PreparedStatement_imports_with_package-level_filtering
+=== RUN   TestFilePathFiltering/Verify_file_path_filtering_excludes_other_packages
+--- PASS: TestFilePathFiltering (0.08s)
 
---- Testing Method Call Searches (Location 2) ---
-✓ PASS: Method Call: Find println calls (8 found)
-✓ PASS: Method Call: Find List.add in SampleApplication
-
---- Testing Constructor Call Searches (Location 3) ---
-✓ PASS: Constructor: Find ArrayList instantiations (3 found)
-✓ PASS: Constructor: Find File instantiations (5 found)
-
---- Testing Annotation Searches (Location 4) ---
-✓ PASS: Annotation: Find @CustomAnnotation on SampleApplication
-
---- Testing Implements Type Searches (Location 5) ---
-✓ PASS: Implements: Find BaseService implements Serializable
-
---- Testing Enum Constant Searches (Location 6) ---
-✓ PASS: Enum Constant: Find ACTIVE enum constant references
-
---- Testing Return Type Searches (Location 7) ---
-✓ PASS: Return Type: Find methods returning String
-
---- Testing Import Searches (Location 8) ---
-✓ PASS: Import: Find java.io.* imports (2 found)
-
---- Testing Variable Declaration Searches (Location 9) ---
-✓ PASS: Variable Declaration: Find String variable declarations
-
---- Testing Type Searches (Location 10) ---
-✓ PASS: Type: Find String type references (15 found)
-
---- Testing Package Declaration Searches (Location 11) ---
-✓ PASS: Package Declaration: Find io.konveyor.demo package
-
---- Testing Field Declaration Searches (Location 12) ---
-✓ PASS: Field Declaration: Find String fields
-
---- Testing Method Declaration Searches (Location 13) ---
-✓ PASS: Method Declaration: Find getter methods with wildcard
-
---- Testing Class Declaration Searches (Location 14) ---
-✓ PASS: Class Declaration: Find SampleApplication class
-
---- Testing customers-tomcat-legacy Project ---
-✓ PASS: Legacy Project: Find @Entity on Customer
-✓ PASS: Legacy Project: Find @Service on CustomerService
-✓ PASS: Legacy Project: Find javax.persistence imports (9 found)
-
---- Testing Priority 1 Advanced Features ---
-✓ PASS: Annotated Element Matching: Find @ActivationConfigProperty with propertyName=destinationLookup
-✓ PASS: Annotated Element Matching: Find @DataSourceDefinition with PostgreSQL driver
-✓ PASS: Annotated Element Matching: Find @DataSourceDefinition with MySQL driver
-✓ PASS: Annotated Element Matching: Find @Column with nullable=false
-✓ PASS: File Path Filtering: Find PreparedStatement imports in persistence package
-✓ PASS: File Path Filtering: Verify filtering excludes other packages
-
-============================================================
-Test Results: 18/18 passed (100%)
-============================================================
+PASS
+ok      github.com/konveyor/java-analyzer-bundle/integration    5.234s
 ```
 
 ## Troubleshooting
@@ -772,15 +736,18 @@ public class SampleApplication extends BaseService { }
 
 #### ✅ Location 0: Default
 **Java Features**: Default search behavior (all locations)
-**Test**: `TestDefaultSearch`
+**Test**: `TestDefaultSearch` (3 sub-tests)
 **Queries**:
-- `java.util.List` → finds all List usage across all location types
+- `io.konveyor.demo.inheritance.BaseService` → finds BaseService across all locations
+- `println` → finds println across all locations
+- `java.io.File` → finds File in imports, constructors, type references, fields, variables
 
 **Java Code Pattern**:
 ```java
 // Matches in multiple contexts: imports, fields, variables, types, etc.
-import java.util.List;
-private List<String> items;
+import java.io.File;
+private File configFile;
+File tempFile = new File("/tmp/data.txt");
 ```
 
 **Symbol Results**: All occurrences across all location types
@@ -813,19 +780,24 @@ EnumExample status = EnumExample.ACTIVE;
 
 #### ✅ Location 7: Return Types
 **Java Features**: Method return type declarations
-**Test**: `TestReturnTypeSearch`
+**Test**: `TestReturnTypeSearch` (3 sub-tests)
 **Queries**:
 - `java.lang.String` → finds all methods returning String
-- `java.util.List` → finds all methods returning List
+- `int` → finds `add` method in Calculator
+- `io.konveyor.demo.EnumExample` → finds `getStatus` method in Calculator
 
-**Java Code Pattern** (test-project/SampleApplication.java):
+**Java Code Pattern**:
 ```java
-public String getName() {              // String return type
+public String getName() {              // String return type (SampleApplication)
     return applicationName;
 }
 
-public List<String> getItems() {       // List return type
-    return items;
+public int add(int a, int b) {        // int return type (Calculator)
+    return a + b;
+}
+
+public EnumExample getStatus() {       // Custom return type (Calculator)
+    return status;
 }
 ```
 
@@ -854,19 +826,27 @@ public void processData() {
 ---
 
 #### ✅ Location 11: Package Declarations
-**Java Features**: Package statements at top of Java files
-**Test**: `TestPackageDeclarationSearch`
+**Java Features**: Package usage via imports and references (not literal package statements)
+**Test**: `TestPackageDeclarationSearch` (8 sub-tests)
 **Queries**:
-- `io.konveyor.demo` → finds all classes in this package
-- `io.konveyor.demo.*` → finds all classes in this package and subpackages
+- `io.konveyor.demo` → may return 0 results (base package never referenced directly)
+- `io.konveyor.demo.inheritance` → finds classes referencing this sub-package
+- `io.konveyor.d*` → wildcard matching across demo sub-packages
+- `java.util` → finds SampleApplication.java (uses java.util imports)
+- `java.sql` → finds persistence package files (uses java.sql imports)
+- `jakarta.*` → finds ServletExample.java (uses jakarta imports)
+- `javax.persistence` → finds entity/Product.java and persistence files
+- `java.io` → finds ServletExample.java (uses java.io imports)
+
+**Note**: PACKAGE search with REFERENCES finds where packages are used in imports/FQNs, not literal `package` statements.
 
 **Java Code Pattern** (all test files):
 ```java
-package io.konveyor.demo;
-package io.konveyor.demo.ordermanagement.model;
+import java.util.List;           // java.util package reference
+import javax.persistence.Entity; // javax.persistence package reference
 ```
 
-**Symbol Results**: Package declaration locations
+**Symbol Results**: Package reference locations in import statements and FQNs
 
 ---
 
@@ -891,17 +871,19 @@ private static final int MAX_RETRIES = 3;  // static final field
 
 #### ✅ Location 13: Method Declarations
 **Java Features**: Method signature declarations
-**Test**: `TestMethodDeclarationSearch`
+**Test**: `TestMethodDeclarationSearch` (4 sub-tests)
 **Queries**:
-- `processData` → finds processData method declarations
-- `get*` → finds all getter methods (wildcard)
-- `print*` → finds all methods starting with print
+- `processData` → finds processData method declaration
+- `getName` → finds getName method declaration
+- `add` → finds add method in Calculator
+- `initialize` → finds initialize method declaration
 
-**Java Code Pattern** (test-project/SampleApplication.java):
+**Java Code Pattern** (test-project/SampleApplication.java, Calculator.java):
 ```java
 public void processData() { }          // processData method
 public String getName() { }            // getName method
-public static void printVersion() { } // static method
+public int add(int a, int b) { }      // add method (Calculator)
+public void initialize() { }           // initialize method
 ```
 
 **Symbol Results**: Method declaration locations
@@ -993,7 +975,7 @@ The integration tests use the following Go packages:
 
 ```go
 require (
-    github.com/konveyor/analyzer-lsp v0.4.0-alpha.1
+    github.com/konveyor/analyzer-lsp v0.8.0
     github.com/sirupsen/logrus v1.9.3
 )
 ```

--- a/java-analyzer-bundle.test/docs/query-reference.md
+++ b/java-analyzer-bundle.test/docs/query-reference.md
@@ -433,15 +433,15 @@ Some location types accept simple names:
 | `TestImportSearch` | 8 | 1 | Verify import statements |
 | `TestVariableDeclarationSearch` | 9 | 3 | Verify local variable declarations |
 | `TestTypeSearch` | 10 | 1 | Verify type reference count |
-| `TestPackageDeclarationSearch` | 11 | 2 | Verify package declarations |
+| `TestPackageDeclarationSearch` | 11 | 8 | Verify package references in imports/FQNs |
 | `TestFieldDeclarationSearch` | 12 | 3 | Verify field declarations |
 | `TestMethodDeclarationSearch` | 13 | 4 | Verify method declarations |
 | `TestClassDeclarationSearch` | 14 | 1 | Verify class declaration |
 | `TestCustomersTomcatLegacy` | 4, 8 | 3 | Migration pattern verification |
 | `TestAnnotatedElementMatching` | 4 | 4 | Annotation attributes matching |
-| `TestFilePathFiltering` | 9 | 2 | File path filtering with includedPaths |
+| `TestFilePathFiltering` | 8 | 2 | File path filtering with includedPaths |
 
-**Total Query Executions**: 40+ unique search queries across 18 test functions covering all 15 location types
+**Total Query Executions**: 47 search queries across 18 test functions covering all 15 location types
 
 ---
 
@@ -451,15 +451,28 @@ Some location types accept simple names:
 
 **Purpose**: Systematic coverage of all location types
 
-**Key Files**:
+**Key Files** (19 Java files):
 - `SampleApplication.java` - Main test file with method calls, constructors, fields, variables
-- `BaseService.java` - Inheritance base class, implements Serializable
-- `DataService.java` - Another BaseService subclass
-- `CustomException.java` - Exception inheritance
-- `CustomAnnotation.java` - Custom annotation definition
+- `Calculator.java` - Return type examples (int, EnumExample)
 - `EnumExample.java` - Enum with constants (location 6)
+- `PackageUsageExample.java` - Package reference patterns
+- `ServletExample.java` - Jakarta servlet example
+- `annotations/CustomAnnotation.java` - Custom annotation definition
+- `annotations/DeprecatedApi.java` - Deprecated API annotation
+- `inheritance/BaseService.java` - Abstract base class, implements Serializable
+- `inheritance/DataService.java` - Another BaseService subclass
+- `inheritance/CustomException.java` - Exception inheritance
+- `jms/MessageProcessor.java` - @MessageDriven with @ActivationConfigProperty
+- `jms/TopicMessageProcessor.java` - Additional JMS example
+- `config/DataSourceConfig.java` - @DataSourceDefinition (PostgreSQL)
+- `config/MySQLDataSourceConfig.java` - @DataSourceDefinition (MySQL)
+- `entity/Product.java` - @Entity, @Column with attributes
+- `persistence/ServiceWithEntityManager.java` - Mixed JPA/JDBC
+- `persistence/JdbcOnlyService.java` - Pure JDBC with PreparedStatement
+- `persistence/AnotherMixedService.java` - Additional mixed pattern
+- `persistence/PureJpaService.java` - Pure JPA (no JDBC)
 
-**Coverage**: Designed to test all 15 location types systematically
+**Coverage**: Designed to test all 15 location types + advanced features systematically
 
 ---
 

--- a/java-analyzer-bundle.test/docs/quick-reference.md
+++ b/java-analyzer-bundle.test/docs/quick-reference.md
@@ -6,9 +6,9 @@ Quick reference for what's tested and what's not in the Java Analyzer Bundle int
 
 ```
 Location Types: 15/15 tested (100%) ✅
-Test Functions: 18
+Test Functions: 18 (47 sub-tests total)
 Advanced Features: 2/2 tested (Priority 1)
-Query Patterns: 40+ unique queries
+Query Patterns: 47 unique queries
 Test Projects: 2 (systematic + real-world)
 ```
 
@@ -31,7 +31,7 @@ Test Projects: 2 (systematic + real-world)
 | **8** | Imports | `java.io.File`, `javax.persistence.Entity` | both |
 | **9** | Variable Decls | `java.lang.String`, `java.io.File` | test-project |
 | **10** | Type Refs | `java.util.ArrayList` | test-project |
-| **11** | Package Decls | `io.konveyor.demo` | test-project |
+| **11** | Package Decls | `io.konveyor.demo.*`, `java.util`, `jakarta.*`, etc. | test-project |
 | **12** | Field Decls | `java.util.List`, `java.io.File` | test-project |
 | **13** | Method Decls | `processData`, `getName`, `add` | test-project |
 | **14** | Class Decls | `SampleApplication` | test-project |
@@ -52,17 +52,35 @@ integration/
 ### Java Test Projects
 ```
 projects/
-├── test-project/             # Systematic pattern coverage
+├── test-project/                    # Systematic pattern coverage (19 Java files)
 │   └── src/main/java/io/konveyor/demo/
-│       ├── SampleApplication.java       # Main test file
-│       ├── inheritance/BaseService.java
+│       ├── SampleApplication.java         # Main test file
+│       ├── Calculator.java                # Return type examples
+│       ├── EnumExample.java               # Enum constant examples
+│       ├── PackageUsageExample.java       # Package reference examples
+│       ├── ServletExample.java            # Jakarta servlet example
 │       ├── annotations/CustomAnnotation.java
-│       └── EnumExample.java
+│       ├── annotations/DeprecatedApi.java
+│       ├── inheritance/BaseService.java
+│       ├── inheritance/DataService.java
+│       ├── inheritance/CustomException.java
+│       ├── jms/MessageProcessor.java      # JMS/EJB annotations
+│       ├── jms/TopicMessageProcessor.java
+│       ├── config/DataSourceConfig.java   # PostgreSQL @DataSourceDefinition
+│       ├── config/MySQLDataSourceConfig.java # MySQL @DataSourceDefinition
+│       ├── entity/Product.java            # JPA @Entity, @Column
+│       ├── persistence/ServiceWithEntityManager.java
+│       ├── persistence/JdbcOnlyService.java
+│       ├── persistence/AnotherMixedService.java
+│       └── persistence/PureJpaService.java
 │
-└── customers-tomcat-legacy/  # Real-world migration
+└── customers-tomcat-legacy/         # Real-world migration (10 Java files)
     └── src/main/java/io/konveyor/demo/ordermanagement/
         ├── model/Customer.java          # JPA entity
-        └── service/CustomerService.java # Spring service
+        ├── service/CustomerService.java # Spring service
+        ├── controller/CustomerController.java
+        ├── repository/CustomerRepository.java
+        └── config/PersistenceConfig.java
 ```
 
 ## Test Functions
@@ -82,7 +100,7 @@ projects/
 | `TestImportSearch` | 8 | 1 | Verify import statements |
 | `TestVariableDeclarationSearch` | 9 | 3 | Verify local variable declarations |
 | `TestTypeSearch` | 10 | 1 | Verify type references |
-| `TestPackageDeclarationSearch` | 11 | 2 | Verify package declarations |
+| `TestPackageDeclarationSearch` | 11 | 8 | Verify package references in imports/FQNs |
 | `TestFieldDeclarationSearch` | 12 | 3 | Verify field declarations |
 | `TestMethodDeclarationSearch` | 13 | 4 | Verify method declarations |
 | `TestClassDeclarationSearch` | 14 | 1 | Verify class declaration |
@@ -180,8 +198,9 @@ make phase2     # Just integration tests
 
 ### Manual Container Run
 ```bash
-# Build image
-podman build -t jdtls-analyzer:test .
+# Build plugin JAR first, then build image (from repository root)
+mvn clean install -DskipTests
+podman build -t jdtls-analyzer:test -f Dockerfile.test .
 
 # Run tests
 podman run --rm \
@@ -191,8 +210,11 @@ podman run --rm \
   --workdir /tests/integration \
   --entrypoint /bin/sh \
   jdtls-analyzer:test \
-  -c "microdnf install -y golang && go mod download && go test -v"
+  -c "go mod download && go test -v"
 ```
+
+**Note**: `Dockerfile.test` requires a pre-built JAR and pre-installs golang. CI uses the
+default `Dockerfile` which builds the JAR from source and installs golang at runtime.
 
 ### Run Specific Test
 ```bash

--- a/java-analyzer-bundle.test/docs/test-projects.md
+++ b/java-analyzer-bundle.test/docs/test-projects.md
@@ -12,16 +12,39 @@ A comprehensive test project designed to cover all search location types (0-14) 
 **Technologies**:
 - Java 17
 - Jakarta Servlet API 5.0
+- javax.persistence-api 2.2 (JPA annotations)
+- javax.ejb-api 3.2.2 (EJB/JMS annotations)
+- javax.jms-api 2.0.1 (JMS API)
+- javax.annotation-api 1.3.2 (@DataSourceDefinition)
 
-**Package Structure**:
+**Package Structure** (19 Java files):
 ```
 io.konveyor.demo/
-├── annotations/          - Custom annotations
-├── inheritance/          - Inheritance and interface examples
-├── SampleApplication.java - Main test class with various patterns
-├── Calculator.java       - Return type examples
-├── EnumExample.java      - Enum constant examples
-└── ServletExample.java   - Jakarta EE servlet example
+├── SampleApplication.java       - Main test class with various patterns
+├── Calculator.java              - Return type examples (int, EnumExample)
+├── EnumExample.java             - Enum constant examples
+├── PackageUsageExample.java     - Package reference patterns
+├── ServletExample.java          - Jakarta EE servlet example
+├── annotations/
+│   ├── CustomAnnotation.java    - Custom annotation definition
+│   └── DeprecatedApi.java       - Deprecated API annotation
+├── inheritance/
+│   ├── BaseService.java         - Abstract base class (Serializable)
+│   ├── DataService.java         - Extends BaseService
+│   └── CustomException.java     - Extends Exception
+├── jms/
+│   ├── MessageProcessor.java    - @MessageDriven with @ActivationConfigProperty
+│   └── TopicMessageProcessor.java - Additional JMS example
+├── config/
+│   ├── DataSourceConfig.java    - @DataSourceDefinition (PostgreSQL)
+│   └── MySQLDataSourceConfig.java - @DataSourceDefinition (MySQL)
+├── entity/
+│   └── Product.java             - @Entity, @Column with attributes
+└── persistence/
+    ├── ServiceWithEntityManager.java - Mixed JPA/JDBC
+    ├── JdbcOnlyService.java     - Pure JDBC with PreparedStatement
+    ├── AnotherMixedService.java - Additional mixed pattern
+    └── PureJpaService.java      - Pure JPA (no JDBC)
 ```
 
 **Covered Location Types**:
@@ -197,33 +220,18 @@ expectedResults: CustomerRepository.java
 
 ---
 
-## Integration Test Strategy
+## Integration Test Status
 
-### Phase 1: Basic Verification Tests (Current)
-- ✅ Verify commands execute without exceptions
-- ✅ Verify parameter parsing
-- ✅ Verify non-null results
+All planned testing phases are complete:
 
-### Phase 2: Search Result Verification (Next)
-1. **Load test projects into Eclipse workspace**
-2. **Verify search result counts**:
-   ```java
-   assertEquals(expectedCount, results.size());
-   ```
-3. **Verify symbol information**:
-   ```java
-   assertEquals("Customer", symbol.getName());
-   assertEquals(SymbolKind.Class, symbol.getKind());
-   assertTrue(symbol.getLocation().getUri().contains("Customer.java"));
-   ```
+- ✅ Commands execute without exceptions
+- ✅ Parameter parsing and validation
+- ✅ Real JDT.LS server with analyzer plugin loaded
+- ✅ Search result verification (symbol names, kinds, locations)
+- ✅ Migration pattern testing (javax→jakarta, Spring, JMS)
+- ✅ Advanced features: annotated element matching, file path filtering
 
-### Phase 3: Migration Pattern Testing
-Test common migration scenarios:
-- **javax → jakarta** namespace migration
-- **Oracle → PostgreSQL** driver migration
-- **JBoss → SLF4J** logging migration
-- **Spring Framework** version upgrades
-- **Legacy servlet → Spring Boot** migration
+**18 test functions, 47 sub-tests, 100% pass rate.**
 
 ---
 
@@ -278,11 +286,12 @@ When adding new test projects:
 
 ---
 
-## Next Steps
+## Completed Milestones
 
-1. **✅ Create test project structures**
-2. **✅ Add sample code covering all location types**
-3. **⏳ Create workspace initialization in tests**
-4. **⏳ Add result verification tests**
-5. **⏳ Create migration scenario tests**
-6. **⏳ Add test documentation for each scenario**
+1. ✅ Create test project structures
+2. ✅ Add sample code covering all location types
+3. ✅ Create workspace initialization in tests (Go LSP client)
+4. ✅ Add result verification tests (18 functions, 47 sub-tests)
+5. ✅ Create migration scenario tests (javax→jakarta, JMS, database drivers)
+6. ✅ Add annotated element matching tests (4 sub-tests)
+7. ✅ Add file path filtering tests (2 sub-tests)

--- a/java-analyzer-bundle.test/integration/client/jdtls_client.go
+++ b/java-analyzer-bundle.test/integration/client/jdtls_client.go
@@ -189,9 +189,7 @@ func (c *JDTLSClient) Initialize() (*protocol.InitializeResult, error) {
 			},
 		},
 		InitializationOptions: map[string]any{
-			"bundles": []string{
-				"/jdtls/plugins/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar",
-			},
+			"bundles":          findAnalyzerBundles("/jdtls/plugins"),
 			"workspaceFolders": []string{string(workspaceURI)},
 		},
 	}
@@ -375,4 +373,17 @@ func (c *JDTLSClient) Shutdown() error {
 // Close is an alias for Shutdown
 func (c *JDTLSClient) Close() error {
 	return c.Shutdown()
+}
+
+// findAnalyzerBundles discovers java-analyzer-bundle JARs in the given directory.
+// This avoids hardcoding the version in the bundle path.
+func findAnalyzerBundles(pluginsDir string) []string {
+	pattern := filepath.Join(pluginsDir, "java-analyzer-bundle.core-*.jar")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		// Fallback: let JDT.LS fail with a clear error rather than silently
+		logrus.Warnf("No analyzer bundle found matching %s", pattern)
+		return []string{}
+	}
+	return matches
 }

--- a/java-analyzer-bundle.test/pom.xml
+++ b/java-analyzer-bundle.test/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>java-analyzer-bundle</artifactId>
 		<groupId>io.konveyor.tackle</groupId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
   <artifactId>java-analyzer-bundle.test</artifactId>

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -11,18 +11,10 @@
 		</location>
 		
 		
-		<!-- 2nd: pick up JDT.LS dependencies-->
-		<!-- Warning: the JDT.LS TP is fluid, as it points to the latest version in the git repo
-	It's not recommended to target fixed releases, such as
-		https://repo.eclipse.org/content/repositories/jdtls-releases/org/eclipse/jdt/ls/org.eclipse.jdt.ls.tp/1.18.0.20221201171036/org.eclipse.jdt.ls.tp-1.18.0.20221201171036.target
-	because those TPs point to upstream transient JDT repositories (known as I-builds), that might be
-		missing every 3 months 
+		<!-- 2nd: pick up JDT.LS dependencies
+		 Dependencies are resolved from standalone repos rather than from the JDT.LS
+		 target platform, because p2 cannot mix InstallableUnit and Target locations.
 		-->
-		
-		<!-- p2 fails to mix both the jdt and the jdt.ls locations
-		<location type="Target"
-			uri="https://raw.githubusercontent.com/eclipse/eclipse.jdt.ls/master/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target" />
-       	-->
 	
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.google.gson" version="2.7.0.v20170129-0911"/>

--- a/java-analyzer-bundle.tp/pom.xml
+++ b/java-analyzer-bundle.tp/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>java-analyzer-bundle</artifactId>
 		<groupId>io.konveyor.tackle</groupId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-analyzer-bundle.tp</artifactId>
 	<name>java-analyzer-bundle :: Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.konveyor.tackle</groupId>
   <artifactId>java-analyzer-bundle</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>java-analyzer-bundle :: parent</name>
   <description>java-analyzer-bundle parent</description>


### PR DESCRIPTION
This should enable Tag v0.9.2 -> 1.0.1 release of the artifact.

fixes #59 

Because we already have 1.0.0 release downstream, this was the best that
I could think of to try and map downstream build to the released build
downstream using the actual artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped bundle version from 1.0.0 → 1.1.0 across modules.
  * Parameterized builds to accept a BUNDLE_VERSION value.

* **CI/CD**
  * Added workflow to compute and propagate artifact versions for releases and snapshots.
  * Added post-release workflow to bump project to next development snapshot and open a PR.

* **Tests**
  * Expanded Phase 1 unit tests (48 → 76) and test project surface (8 → 19 files).

* **Documentation**
  * Updated integration and test docs for JDT.LS 1.51.0 and expanded test guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->