### PR TITLE
Update maven version to 3.9.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN mkdir /output && cp ./build/libs/fernflower.jar /output
 
 FROM registry.access.redhat.com/ubi9/ubi AS addon-build
 RUN dnf install -y java-21-openjdk-devel wget zip --nodocs --setopt=install_weak_deps=0 && dnf clean all && rm -rf /var/cache/dnf
-RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz && \
+RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/local/ && \
     rm /tmp/apache-maven.tar.gz
 WORKDIR /app
 COPY ./ /app/
 ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk
-RUN /usr/local/apache-maven-3.9.14/bin/mvn clean install -DskipTests=true
+RUN /usr/local/apache-maven-3.9.15/bin/mvn clean install -DskipTests=true
 # Download maven index data
 WORKDIR /maven-index-data
 RUN set -e; \
@@ -44,7 +44,7 @@ RUN microdnf install -y python39 java-1.8.0-openjdk-devel java-21-openjdk-devel 
 ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk
 # Specify Java 1.8 home for usage with gradle wrappers
 ENV JAVA8_HOME /usr/lib/jvm/java-1.8.0-openjdk
-ENV M2_HOME /usr/local/apache-maven-3.9.14
+ENV M2_HOME /usr/local/apache-maven-3.9.15
 
 # Copy "download sources" gradle task. This is needed to download project sources.
 RUN mkdir /root/.gradle
@@ -54,8 +54,8 @@ COPY ./gradle/build-v9.gradle /usr/local/etc/task-v9.gradle
 COPY hack/maven.default.index /usr/local/etc/maven.default.index
 
 COPY --from=jdtls-download /jdtls /jdtls/
-COPY --from=addon-build /usr/local/apache-maven-3.9.14/ /usr/local/apache-maven-3.9.14/
-RUN ln -s /usr/local/apache-maven-3.9.14/bin/mvn /usr/bin/mvn
+COPY --from=addon-build /usr/local/apache-maven-3.9.15/ /usr/local/apache-maven-3.9.15/
+RUN ln -s /usr/local/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
 COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/1.0.0-SNAPSHOT/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/plugins/
 COPY --from=addon-build /root/.m2/repository/io/konveyor/tackle/java-analyzer-bundle.core/1.0.0-SNAPSHOT/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar /jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar
 COPY --from=fernflower /output/fernflower.jar /bin/fernflower.jar

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -30,11 +30,11 @@ RUN microdnf install -y python39 java-1.8.0-openjdk-devel java-21-openjdk-devel 
 ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk
 # Specify Java 1.8 home for usage with gradle wrappers
 ENV JAVA8_HOME /usr/lib/jvm/java-1.8.0-openjdk
-RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz && \
+RUN curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/local/ && \
-    ln -s /usr/local/apache-maven-3.9.14/bin/mvn /usr/bin/mvn && \
+    ln -s /usr/local/apache-maven-3.9.15/bin/mvn /usr/bin/mvn && \
     rm /tmp/apache-maven.tar.gz
-ENV M2_HOME /usr/local/apache-maven-3.9.14
+ENV M2_HOME /usr/local/apache-maven-3.9.15
 
 # Copy "download sources" gradle task. This is needed to download project sources.
 RUN mkdir /root/.gradle


### PR DESCRIPTION
Fixes:
```
curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz
curl: (22) The requested URL returned error: 404
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache Maven from version 3.9.14 to 3.9.15 in Docker build and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->