### PR TITLE
Fix jdtls download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -fsSL -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-1.54.0-202511261751.tar.gz &&\
+RUN curl -fsSL -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.60.0/jdt-language-server-1.60.0-202606262232.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.51.0/jdt-language-server-1.51.0-202510022025.tar.gz &&\
+RUN curl -fsSL -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-1.54.0-202511261751.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -s -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.51.0/jdt-language-server-1.51.0-202510022025.tar.gz &&\
+RUN curl -fsSL -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-1.54.0-202511261751.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner --no-same-permissions &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi AS jdtls-download
 WORKDIR /jdtls
-RUN curl -fsSL -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-1.54.0-202511261751.tar.gz &&\
+RUN curl -fsSL -o jdtls.tar.gz https://download.eclipse.org/jdtls/milestones/1.60.0/jdt-language-server-1.60.0-202606262232.tar.gz &&\
 	tar -xvf jdtls.tar.gz --no-same-owner --no-same-permissions &&\
 	chmod 755 /jdtls/bin/jdtls &&\
         rm -rf jdtls.tar.gz

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -2,12 +2,12 @@
 <?pde version="3.8"?>
 <target name="Java Analyzer Target Platform">
 	<locations>
-		<!-- 1st: pick up JDT.LS bits (1.51.0)
+		<!-- 1st: pick up JDT.LS bits (1.60.0)
 		-->
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner"
 			includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
-			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.54.0.202511261751/"/>
+			<repository location="https://download.eclipse.org/jdtls/milestones/1.60.0/repository"/>
 		</location>
 		
 		

--- a/java-analyzer-bundle.tp/java-analyzer-bundle.target
+++ b/java-analyzer-bundle.tp/java-analyzer-bundle.target
@@ -7,7 +7,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner"
 			includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
-			<repository location="https://download.eclipse.org/jdtls/milestones/1.51.0/repository"/>
+			<repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.54.0.202511261751/"/>
 		</location>
 		
 		


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Java language server to a newer release to improve compatibility and stability.
  * Updated the Java analysis bundle to use the latest available language server snapshot/repository, keeping the analysis environment consistent with the new server version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->